### PR TITLE
[f5] various fixes: raceconditions, cleanup optimization, logging, reworked SNAT handling

### DIFF
--- a/internal/agent/f5/agent.go
+++ b/internal/agent/f5/agent.go
@@ -133,11 +133,8 @@ func (a *Agent) Run() {
 		DoWithJobDetails(a.PendingSyncLoop); err != nil {
 		log.Fatal(err)
 	}
-	if _, err := s.Every(24).Hours().Do(a.cleanOrphanSelfIPs); err != nil {
-		log.WithField("cron", "cleanupOrphanSelfIPs").Error(err)
-	}
-	if _, err := s.Every(24).Hours().Do(a.cleanOrphanRDsAndVLANs); err != nil {
-		log.WithField("cron", "cleanOrphanRDsAndVLANs").Error(err)
+	if _, err := s.Every(24).Hours().Do(a.cleanupL2); err != nil {
+		log.WithField("cron", "cleanupL2").Error(err)
 	}
 	s.StartBlocking()
 }

--- a/internal/controller/endpoint_test.go
+++ b/internal/controller/endpoint_test.go
@@ -149,7 +149,7 @@ func (t *SuiteTest) TestEndpointTargetForeignNetwork() {
 
 	fakeServiceClient := fake.ServiceClient()
 	fakeServiceClient.EndpointLocator = func(opts gophercloud.EndpointOpts) (string, error) {
-		return "http://localhost:8931/", nil
+		return "http://127.0.0.1:8931/", nil
 	}
 	token := gopherpolicy.Token{ProviderClient: fakeServiceClient.ProviderClient}
 	res := t.c.PostEndpointHandler(endpoint.PostEndpointParams{HTTPRequest: &http.Request{}, Body: &models.Endpoint{
@@ -159,7 +159,7 @@ func (t *SuiteTest) TestEndpointTargetForeignNetwork() {
 	}}, &token)
 	assert.NotNil(t.T(), res)
 	assert.IsType(t.T(), &endpoint.PostEndpointBadRequest{}, res)
-	assert.Equal(t.T(), fmt.Sprintf("Resource not found: [GET http://localhost:8931/v2.0/networks/%s], error message: 404 page not found\n", network),
+	assert.Equal(t.T(), fmt.Sprintf("Resource not found: [GET http://127.0.0.1:8931/v2.0/networks/%s], error message: 404 page not found\n", network),
 		res.(*endpoint.PostEndpointBadRequest).Payload.Message)
 }
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -137,6 +137,7 @@ func (t *SuiteTest) SetupSuite() {
 
 	th.SetupPersistentPortHTTP(t.T(), 8931)
 	t.c = NewController(pool, spec, &neutron.NeutronClient{ServiceClient: fake.ServiceClient()})
+	t.c.neutron.InitCache()
 
 	// Run migration
 	migrator, err := mgx.New(migrations.Migrations)
@@ -180,4 +181,5 @@ func (t *SuiteTest) AfterTest(_, _ string) {
 	}
 
 	t.ResetHttpServer()
+	t.c.neutron.ResetCache()
 }

--- a/internal/neutron/neutron_test.go
+++ b/internal/neutron/neutron_test.go
@@ -24,7 +24,6 @@ import (
 	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/fixture"
 	"github.com/hashicorp/golang-lru/v2/expirable"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/sapcc/archer/internal/config"
 )
@@ -44,43 +43,6 @@ const GetNetworkResponseFixture = `
 			}
 		]
     }
-}
-`
-const PostPortRequestFixture = `{"port":{"binding:host_id":"testhost","device_id":"9bf57c58-5d9f-418b-a879-44d83e194ad0","device_owner":"network:f5snat","fixed_ips":[{"subnet_id":"a0304c3a-4f08-4c43-88af-d796509c97d2"}],"name":"local-testdevicehost","network_id":"9bf57c58-5d9f-418b-a879-44d83e194ad0","tenant_id":"test-project-1"}}`
-const PostPortResponseFixture = `
-{
-	"port": {
-		"admin_state_up": true,
-		"allowed_address_pairs": [],
-		"binding:host_id": "testhost",
-		"binding:profile": {},
-		"binding:vif_details": {},
-		"binding:vif_type": "unbound",
-		"binding:vnic_type": "normal",
-		"created_at": "2021-03-18T14:20:00Z",
-		"data_plane_status": null,
-		"description": "",
-		"device_id": "9bf57c58-5d9f-418b-a879-44d83e194ad0",
-		"device_owner": "network:f5snat",
-		"fixed_ips": [
-			{
-				"ip_address": "123.123.123.123",
-				"subnet_id": "a0304c3a-4f08-4c43-88af-d796509c97d2"
-			}
-		],
-		"id": "9bf57c58-5d9f-418b-a879-44d83e194ad0",
-		"ip_allocation": "immediate",
-		"mac_address": "fa:16:3e:4c:2c:2c",
-		"name": "local-testdevicehost",
-		"network_id": "9bf57c58-5d9f-418b-a879-44d83e194ad0",
-		"port_security_enabled": true,
-		"project_id": "test-project-1",
-		"qos_network_policy_id": null,
-		"revision_number": 1,
-		"security_groups": [],
-		"status": "DOWN",
-		"tags": []
-	}
 }
 `
 
@@ -134,24 +96,4 @@ func TestNeutronClient_GetNetworkSegment(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestNeutronClient_AllocateSNATNeutronPort(t *testing.T) {
-	th.SetupPersistentPortHTTP(t, 8931)
-	defer th.TeardownHTTP()
-	config.Global.Agent.PhysicalNetwork = "physnet1"
-	config.Global.Default.Host = "testhost"
-	fixture.SetupHandler(t, "/v2.0/networks/"+NetworkIDFixture, "GET",
-		"", GetNetworkResponseFixture, http.StatusOK)
-	fixture.SetupHandler(t, "/v2.0/ports", "POST",
-		PostPortRequestFixture, PostPortResponseFixture, http.StatusCreated)
-
-	n := &NeutronClient{
-		ServiceClient: fake.ServiceClient(),
-	}
-	h := "testdevicehost"
-
-	got, err := n.AllocateSNATPort(h, NetworkIDFixture)
-	assert.Nil(t, err)
-	assert.Equal(t, "local-testdevicehost", got.Name)
 }


### PR DESCRIPTION
This patch unifies selfip creation for endpoints and services, fixes tests, and remove
obosolete code.
