### PR TITLE
F5: Make L4 and TCP profile configurable, seg-id refresh outside of tx

### DIFF
--- a/internal/agent/f5/as3/bigip.go
+++ b/internal/agent/f5/as3/bigip.go
@@ -164,7 +164,7 @@ func GetEndpointTenants(endpoints []*ExtendedEndpoint) Tenant {
 			})
 		} else {
 			class = "Service_L4"
-			l4profile = &Pointer{BigIP: "/Common/cc_fastL4_profile"}
+			l4profile = &Pointer{BigIP: config.Global.Agent.L4Profile}
 		}
 
 		services[endpointName] = Service{
@@ -175,6 +175,7 @@ func GetEndpointTenants(endpoints []*ExtendedEndpoint) Tenant {
 			PersistanceMethods:  []string{},
 			Pool:                Pointer{BigIP: pool},
 			ProfileL4:           l4profile,
+			ProfileTCP:          &Pointer{BigIP: config.Global.Agent.TCPProfile},
 			Snat:                Pointer{BigIP: snat},
 			TranslateServerPort: true,
 			VirtualPort:         endpoint.ServicePortNr,

--- a/internal/agent/f5/as3/bigip_test.go
+++ b/internal/agent/f5/as3/bigip_test.go
@@ -1,0 +1,62 @@
+// Copyright 2024 SAP SE
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package as3
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sapcc/archer/internal/config"
+	"github.com/sapcc/archer/models"
+)
+
+func TestGetEndpointTenants(t *testing.T) {
+
+	config.Global.Agent.L4Profile = "test-l4-profile"
+	config.Global.Agent.TCPProfile = "test-tcp-profile"
+	endpoints := []*ExtendedEndpoint{
+		{
+			Endpoint: models.Endpoint{
+				CreatedAt:   time.Time{},
+				Description: "test-description",
+				ID:          "3ad9b1f0-4e5a-44c3-ada6-71696925ae64",
+				IPAddress:   "1.2.3.4",
+				Name:        "test-name",
+				ProjectID:   "test-project",
+				ServiceID:   strfmt.UUID("4e50bf87-e597-41f2-9ce0-83d3e24dedf3"),
+				Target:      models.EndpointTarget{},
+				UpdatedAt:   time.Time{},
+			},
+			ProxyProtocol: false,
+			Port: &ports.Port{
+				FixedIPs: []ports.IP{{IPAddress: "1.2.3.4"}},
+			},
+			SegmentId: swag.Int(1),
+		},
+	}
+	tenant := GetEndpointTenants(endpoints)
+	assert.NotNil(t, tenant)
+	json, err := tenant.MarshalJSON()
+	assert.Nil(t, err)
+
+	expectedJSON := `{"class":"Tenant","si-endpoints":{"class":"Application","endpoint-3ad9b1f0-4e5a-44c3-ada6-71696925ae64":{"label":"endpoint-3ad9b1f0-4e5a-44c3-ada6-71696925ae64","class":"Service_L4","allowVlans":["/Common/vlan-1"],"iRules":[],"mirroring":"L4","persistenceMethods":[],"pool":{"bigip":"/Common/Shared/pool-4e50bf87-e597-41f2-9ce0-83d3e24dedf3"},"profileL4":{"bigip":"test-l4-profile"},"profileTCP":{"bigip":"test-tcp-profile"},"snat":{"bigip":"/Common/Shared/snatpool-4e50bf87-e597-41f2-9ce0-83d3e24dedf3"},"virtualAddresses":["1.2.3.4%1"],"translateServerPort":true,"virtualPort":0},"template":"generic"}}`
+	assert.JSONEq(t, expectedJSON, string(json), "Tenant JSON should be equal")
+
+}

--- a/internal/agent/f5/endpoints_test.go
+++ b/internal/agent/f5/endpoints_test.go
@@ -142,6 +142,9 @@ const PostBigIPFixture = `{
           "profileL4": {
             "bigip": "/Common/cc_fastL4_profile"
           },
+          "profileTCP": {
+            "bigip": "/Common/cc_tcp_profile"
+          },
           "snat": {
             "bigip": "/Common/Shared/snatpool-a0a0a0a0-a0a0-4a0a-8a0a-0a0a0a0a0a0a"
           },
@@ -185,6 +188,8 @@ func TestAgent_ProcessEndpoint(t *testing.T) {
 	th.SetupPersistentPortHTTP(t, 8931)
 	defer th.TeardownHTTP()
 	config.Global.Agent.PhysicalNetwork = "physnet1"
+	config.Global.Agent.L4Profile = "/Common/cc_fastL4_profile"
+	config.Global.Agent.TCPProfile = "/Common/cc_tcp_profile"
 	fixture.SetupHandler(t, "/v2.0/networks/"+network.String(), "GET",
 		"", GetNetworkResponseFixture, http.StatusOK)
 	fixture.SetupHandler(t, "/v2.0/networks/"+serviceNetwork.String(), "GET",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,6 +97,8 @@ type Agent struct {
 	ServiceRequireApproval bool          `long:"service-require-approval" ini-name:"service_require_approval" description:"Service requires approval."`
 	ServiceUpstreamHost    string        `long:"service-upstream-host" ini-name:"service_upstream_host" description:"Service upstream host."`
 	ServiceProxyPath       string        `long:"service-proxy-path" ini-name:"service_proxy_path" description:"Service proxy path." default:"/var/run/socat-proxy/proxy.sock"`
+	L4Profile              string        `long:"l4-profile" ini-name:"l4_profile" description:"L4 profile to use for F5 endpoint service." default:"/Common/fastL4"`
+	TCPProfile             string        `long:"tcp-profile" ini-name:"tcp_profile" description:"TCP profile to use for F5 endpoint service." default:"/Common/tcp"`
 }
 
 type AuthInfo struct {


### PR DESCRIPTION
This PR introduces two new config variables and allow the TCP and L4 Profiles to be customized.
Fixes #313

```ini
[agent]
tcp_profile = "/Common/tcp_profile"
l4_profile = "/Common/l4_profile"
```