### PR TITLE
use new go-bits/audittools API 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/prometheus/client_golang v1.20.5
 	github.com/rs/cors v1.11.1
 	github.com/sapcc/go-api-declarations v1.13.0
-	github.com/sapcc/go-bits v0.0.0-20241108154105-90f09fab5e0a
+	github.com/sapcc/go-bits v0.0.0-20241204103411-aa06a1b92800
 	github.com/sethvargo/go-retry v0.3.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.10.0
@@ -47,6 +47,7 @@ require (
 	github.com/z0ne-dev/mgx/v2 v2.0.1
 	golang.org/x/net v0.32.0
 	golang.org/x/sync v0.10.0
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -93,6 +94,7 @@ require (
 	github.com/rabbitmq/amqp091-go v1.10.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
+	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/ztrue/tracerr v0.3.0 // indirect
 	go.mongodb.org/mongo-driver v1.14.0 // indirect
@@ -105,6 +107,5 @@ require (
 	golang.org/x/term v0.27.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,8 @@ github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sapcc/go-api-declarations v1.13.0 h1:4ufQUF7rwhLz7kPDVFCkw6CpQ8VeO2clJg4pjwTTpTU=
 github.com/sapcc/go-api-declarations v1.13.0/go.mod h1:83R3hTANhuRXt/pXDby37IJetw8l7DG41s33Tp9NXxI=
-github.com/sapcc/go-bits v0.0.0-20241108154105-90f09fab5e0a h1:bPQTis7tljyH01pE+8BDssaqfUvkdxYguzONq7cVrZM=
-github.com/sapcc/go-bits v0.0.0-20241108154105-90f09fab5e0a/go.mod h1:edzu9ZBNooNFNX1J70nkhV2cOibYvADvr4C39K0stbc=
+github.com/sapcc/go-bits v0.0.0-20241204103411-aa06a1b92800 h1:6nwYrzWL5mB8kg5A29nQLLg+cx4/onf2BPhHzCVEohA=
+github.com/sapcc/go-bits v0.0.0-20241204103411-aa06a1b92800/go.mod h1:Fa38gpJczKo2cgyb21f2RkrvqvaFtLXztXyYgTZ7ZVE=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
 github.com/sethvargo/go-retry v0.3.0 h1:EEt31A35QhrcRZtrYFDTBg91cqZVnFL2navjDrah2SE=
@@ -370,6 +370,7 @@ google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWn
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=

--- a/internal/auth/keystone.go
+++ b/internal/auth/keystone.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
 	"github.com/sapcc/go-bits/gopherpolicy"
 	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 
 	"github.com/sapcc/archer/internal/config"
 )
@@ -48,7 +49,7 @@ func InitializeKeystone(providerClient *gophercloud.ProviderClient) (*Keystone, 
 		IdentityV3: keystoneV3,
 		Cacher:     gopherpolicy.InMemoryCacher(),
 	}
-	if err := tv.LoadPolicyFile(config.Global.ApiSettings.PolicyFile); err != nil {
+	if err := tv.LoadPolicyFile(config.Global.ApiSettings.PolicyFile, yaml.Unmarshal); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
The only behavior change from this is that the debug log messages "Notification sent" and "Notification failed" are replaced with Prometheus counters `audittools_{successful,failed}_submissions`.

I would like to get this merged soonish to facilitate a larger cleanup of the audittools package that turns `type AuditTrail` and `func NewEvent` from public API into implementation details.

Note that package audittools now also offers a mock implementation that can be used to assert on the content of generated audit events in tests. Look for type audittools.MockAuditor for more information.

---

The go-bits update that is part of this PR also turns `gopkg.in/yaml.v2` from an implicit into an explicit dependency. This is because of an API change in go-bits/gopherpolicy, which makes the YAML parser dependency optional for applications that only use `policy.json`.