### PR TITLE
Dockerfile: use CHECK_SKIPS_FUNCTIONAL_TEST during test target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN apk add --no-cache --no-progress git make py3-pip postgresql \
 COPY --from=builder /go /go
 COPY --from=builder /src /src
 
-RUN make -C /src static-check
+RUN CHECK_SKIPS_FUNCTIONAL_TEST=true make -C /src static-check
 
 # Some things like postgres do not like to run as root. For simplicity, just always run as an unprivileged user,
 # but for it to be able to read the go cache, we need to allow it.

--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -22,6 +22,8 @@ binaries:
 
 dockerfile:
   enabled: true
+  checkEnv:
+    - CHECK_SKIPS_FUNCTIONAL_TEST=true
   entrypoint: [ "/usr/bin/archer-server" ]
   extraPackages: [ "haproxy" ]
   extraBuildDirectives:


### PR DESCRIPTION
Following a change to our go-makefile-maker CI, we are now using the `test` target declared in the Dockerfile. This avoids having to maintain a lot of special cases in the CI pipeline definition, but to make it work with Archer, we need to set the `CHECK_SKIPS_FUNCTIONAL_TEST` that previously was set by the CI as an implicit contract.