### PR TITLE
Add validations in Swagger and increase tag length

### DIFF
--- a/client/endpoint/put_endpoint_endpoint_id_responses.go
+++ b/client/endpoint/put_endpoint_endpoint_id_responses.go
@@ -504,7 +504,7 @@ func (o *PutEndpointEndpointIDBody) validateTags(formats strfmt.Registry) error 
 
 	for i := 0; i < len(o.Tags); i++ {
 
-		if err := validate.MaxLength("body"+"."+"tags"+"."+strconv.Itoa(i), "body", o.Tags[i], 64); err != nil {
+		if err := validate.MaxLength("body"+"."+"tags"+"."+strconv.Itoa(i), "body", o.Tags[i], 128); err != nil {
 			return err
 		}
 

--- a/internal/db/migrations/migration.go
+++ b/internal/db/migrations/migration.go
@@ -305,4 +305,11 @@ var Migrations = mgx.Migrations(
 		`)
 		return err
 	}),
+	mgx.NewMigration("increase_tag_length", func(ctx context.Context, commands mgx.Commands) error {
+		_, err := commands.Exec(ctx, `
+			ALTER TABLE service ALTER COLUMN tags TYPE VARCHAR(128)[];
+			ALTER TABLE endpoint ALTER COLUMN tags TYPE VARCHAR(128)[];
+		`)
+		return err
+	}),
 )

--- a/models/endpoint.go
+++ b/models/endpoint.go
@@ -253,7 +253,7 @@ func (m *Endpoint) validateTags(formats strfmt.Registry) error {
 
 	for i := 0; i < len(m.Tags); i++ {
 
-		if err := validate.MaxLength("tags"+"."+strconv.Itoa(i), "body", m.Tags[i], 64); err != nil {
+		if err := validate.MaxLength("tags"+"."+strconv.Itoa(i), "body", m.Tags[i], 128); err != nil {
 			return err
 		}
 

--- a/models/project.go
+++ b/models/project.go
@@ -39,11 +39,7 @@ type Project string
 func (m Project) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := validate.MinLength("", "body", string(m), 32); err != nil {
-		return err
-	}
-
-	if err := validate.MaxLength("", "body", string(m), 32); err != nil {
+	if err := validate.MaxLength("", "body", string(m), 36); err != nil {
 		return err
 	}
 

--- a/models/rbacpolicy.go
+++ b/models/rbacpolicy.go
@@ -56,6 +56,8 @@ type Rbacpolicy struct {
 
 	// The ID of the project to which the RBAC policy will be enforced.
 	// Example: 666da95112694b37b3efb0913de3f499
+	// Max Length: 32
+	// Min Length: 32
 	Target string `json:"target,omitempty"`
 
 	// target type
@@ -83,6 +85,10 @@ func (m *Rbacpolicy) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateServiceID(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateTarget(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -148,6 +154,22 @@ func (m *Rbacpolicy) validateServiceID(formats strfmt.Registry) error {
 	}
 
 	if err := validate.FormatOf("service_id", "body", "uuid", m.ServiceID.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Rbacpolicy) validateTarget(formats strfmt.Registry) error {
+	if swag.IsZero(m.Target) { // not required
+		return nil
+	}
+
+	if err := validate.MinLength("target", "body", m.Target, 32); err != nil {
+		return err
+	}
+
+	if err := validate.MaxLength("target", "body", m.Target, 32); err != nil {
 		return err
 	}
 

--- a/models/rbacpolicy.go
+++ b/models/rbacpolicy.go
@@ -56,8 +56,7 @@ type Rbacpolicy struct {
 
 	// The ID of the project to which the RBAC policy will be enforced.
 	// Example: 666da95112694b37b3efb0913de3f499
-	// Max Length: 32
-	// Min Length: 32
+	// Max Length: 36
 	Target string `json:"target,omitempty"`
 
 	// target type
@@ -165,11 +164,7 @@ func (m *Rbacpolicy) validateTarget(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.MinLength("target", "body", m.Target, 32); err != nil {
-		return err
-	}
-
-	if err := validate.MaxLength("target", "body", m.Target, 32); err != nil {
+	if err := validate.MaxLength("target", "body", m.Target, 36); err != nil {
 		return err
 	}
 

--- a/models/rbacpolicycommon.go
+++ b/models/rbacpolicycommon.go
@@ -48,6 +48,8 @@ type Rbacpolicycommon struct {
 	// The ID of the project to which the RBAC policy will be enforced.
 	// Example: 666da95112694b37b3efb0913de3f499
 	// Required: true
+	// Max Length: 32
+	// Min Length: 32
 	Target *string `json:"target"`
 
 	// target type
@@ -117,6 +119,14 @@ func (m *Rbacpolicycommon) validateProjectID(formats strfmt.Registry) error {
 func (m *Rbacpolicycommon) validateTarget(formats strfmt.Registry) error {
 
 	if err := validate.Required("target", "body", m.Target); err != nil {
+		return err
+	}
+
+	if err := validate.MinLength("target", "body", *m.Target, 32); err != nil {
+		return err
+	}
+
+	if err := validate.MaxLength("target", "body", *m.Target, 32); err != nil {
 		return err
 	}
 

--- a/models/rbacpolicycommon.go
+++ b/models/rbacpolicycommon.go
@@ -48,8 +48,7 @@ type Rbacpolicycommon struct {
 	// The ID of the project to which the RBAC policy will be enforced.
 	// Example: 666da95112694b37b3efb0913de3f499
 	// Required: true
-	// Max Length: 32
-	// Min Length: 32
+	// Max Length: 36
 	Target *string `json:"target"`
 
 	// target type
@@ -122,11 +121,7 @@ func (m *Rbacpolicycommon) validateTarget(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.MinLength("target", "body", *m.Target, 32); err != nil {
-		return err
-	}
-
-	if err := validate.MaxLength("target", "body", *m.Target, 32); err != nil {
+	if err := validate.MaxLength("target", "body", *m.Target, 36); err != nil {
 		return err
 	}
 

--- a/models/service.go
+++ b/models/service.go
@@ -532,7 +532,7 @@ func (m *Service) validateTags(formats strfmt.Registry) error {
 
 	for i := 0; i < len(m.Tags); i++ {
 
-		if err := validate.MaxLength("tags"+"."+strconv.Itoa(i), "body", m.Tags[i], 64); err != nil {
+		if err := validate.MaxLength("tags"+"."+strconv.Itoa(i), "body", m.Tags[i], 128); err != nil {
 			return err
 		}
 

--- a/models/service.go
+++ b/models/service.go
@@ -41,6 +41,7 @@ type Service struct {
 
 	// Availability zone of this service.
 	// Example: AZ-A
+	// Max Length: 64
 	AvailabilityZone *string `json:"availability_zone"`
 
 	// created at
@@ -70,6 +71,7 @@ type Service struct {
 
 	// Device host.
 	// Read Only: true
+	// Max Length: 64
 	Host *string `json:"host,omitempty"`
 
 	// The ID of the resource.
@@ -140,6 +142,10 @@ type Service struct {
 func (m *Service) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateAvailabilityZone(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateCreatedAt(formats); err != nil {
 		res = append(res, err)
 	}
@@ -149,6 +155,10 @@ func (m *Service) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateHealthStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateHost(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -203,6 +213,18 @@ func (m *Service) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *Service) validateAvailabilityZone(formats strfmt.Registry) error {
+	if swag.IsZero(m.AvailabilityZone) { // not required
+		return nil
+	}
+
+	if err := validate.MaxLength("availability_zone", "body", *m.AvailabilityZone, 64); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -268,6 +290,18 @@ func (m *Service) validateHealthStatus(formats strfmt.Registry) error {
 
 	// value enum
 	if err := m.validateHealthStatusEnum("health_status", "body", *m.HealthStatus); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Service) validateHost(formats strfmt.Registry) error {
+	if swag.IsZero(m.Host) { // not required
+		return nil
+	}
+
+	if err := validate.MaxLength("host", "body", *m.Host, 64); err != nil {
 		return err
 	}
 

--- a/models/service_updatable.go
+++ b/models/service_updatable.go
@@ -247,7 +247,7 @@ func (m *ServiceUpdatable) validateTags(formats strfmt.Registry) error {
 
 	for i := 0; i < len(m.Tags); i++ {
 
-		if err := validate.MaxLength("tags"+"."+strconv.Itoa(i), "body", m.Tags[i], 64); err != nil {
+		if err := validate.MaxLength("tags"+"."+strconv.Itoa(i), "body", m.Tags[i], 128); err != nil {
 			return err
 		}
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -290,7 +290,7 @@ func init() {
                   "type": "array",
                   "items": {
                     "type": "string",
-                    "maxLength": 64
+                    "maxLength": 128
                   },
                   "x-nullable": true
                 }
@@ -1431,7 +1431,7 @@ func init() {
           "type": "array",
           "items": {
             "type": "string",
-            "maxLength": 64
+            "maxLength": 128
           },
           "x-nullable": true
         },
@@ -1801,7 +1801,7 @@ func init() {
           "type": "array",
           "items": {
             "type": "string",
-            "maxLength": 64
+            "maxLength": 128
           },
           "x-nullable": true
         },
@@ -1901,7 +1901,7 @@ func init() {
           "type": "array",
           "items": {
             "type": "string",
-            "maxLength": 64
+            "maxLength": 128
           }
         },
         "visibility": {
@@ -1978,7 +1978,7 @@ func init() {
     "not-tags": {
       "type": "array",
       "items": {
-        "maxLength": 64,
+        "maxLength": 128,
         "type": "string"
       },
       "description": "Filter for resources not having tags, multiple not-tags are considered as logical AND.\nShould be provided in a comma separated list.\n",
@@ -1988,7 +1988,7 @@ func init() {
     "not-tags-any": {
       "type": "array",
       "items": {
-        "maxLength": 64,
+        "maxLength": 128,
         "type": "string"
       },
       "description": "Filter for resources not having tags, multiple tags are considered as logical OR.\nShould be provided in a comma separated list.\n",
@@ -2019,7 +2019,7 @@ func init() {
     "tags": {
       "type": "array",
       "items": {
-        "maxLength": 64,
+        "maxLength": 128,
         "type": "string"
       },
       "description": "Filter for tags, multiple tags are considered as logical AND.\nShould be provided in a comma separated list.\n",
@@ -2029,7 +2029,7 @@ func init() {
     "tags-any": {
       "type": "array",
       "items": {
-        "maxLength": 64,
+        "maxLength": 128,
         "type": "string"
       },
       "description": "Filter for tags, multiple tags are considered as logical OR.\nShould be provided in a comma separated list.\n",
@@ -2164,7 +2164,7 @@ func init() {
           {
             "type": "array",
             "items": {
-              "maxLength": 64,
+              "maxLength": 128,
               "type": "string"
             },
             "description": "Filter for tags, multiple tags are considered as logical AND.\nShould be provided in a comma separated list.\n",
@@ -2174,7 +2174,7 @@ func init() {
           {
             "type": "array",
             "items": {
-              "maxLength": 64,
+              "maxLength": 128,
               "type": "string"
             },
             "description": "Filter for tags, multiple tags are considered as logical OR.\nShould be provided in a comma separated list.\n",
@@ -2184,7 +2184,7 @@ func init() {
           {
             "type": "array",
             "items": {
-              "maxLength": 64,
+              "maxLength": 128,
               "type": "string"
             },
             "description": "Filter for resources not having tags, multiple not-tags are considered as logical AND.\nShould be provided in a comma separated list.\n",
@@ -2194,7 +2194,7 @@ func init() {
           {
             "type": "array",
             "items": {
-              "maxLength": 64,
+              "maxLength": 128,
               "type": "string"
             },
             "description": "Filter for resources not having tags, multiple tags are considered as logical OR.\nShould be provided in a comma separated list.\n",
@@ -2384,7 +2384,7 @@ func init() {
                   "type": "array",
                   "items": {
                     "type": "string",
-                    "maxLength": 64
+                    "maxLength": 128
                   },
                   "x-nullable": true
                 }
@@ -3009,7 +3009,7 @@ func init() {
           {
             "type": "array",
             "items": {
-              "maxLength": 64,
+              "maxLength": 128,
               "type": "string"
             },
             "description": "Filter for tags, multiple tags are considered as logical AND.\nShould be provided in a comma separated list.\n",
@@ -3019,7 +3019,7 @@ func init() {
           {
             "type": "array",
             "items": {
-              "maxLength": 64,
+              "maxLength": 128,
               "type": "string"
             },
             "description": "Filter for tags, multiple tags are considered as logical OR.\nShould be provided in a comma separated list.\n",
@@ -3029,7 +3029,7 @@ func init() {
           {
             "type": "array",
             "items": {
-              "maxLength": 64,
+              "maxLength": 128,
               "type": "string"
             },
             "description": "Filter for resources not having tags, multiple not-tags are considered as logical AND.\nShould be provided in a comma separated list.\n",
@@ -3039,7 +3039,7 @@ func init() {
           {
             "type": "array",
             "items": {
-              "maxLength": 64,
+              "maxLength": 128,
               "type": "string"
             },
             "description": "Filter for resources not having tags, multiple tags are considered as logical OR.\nShould be provided in a comma separated list.\n",
@@ -3588,7 +3588,7 @@ func init() {
           "type": "array",
           "items": {
             "type": "string",
-            "maxLength": 64
+            "maxLength": 128
           },
           "x-nullable": true
         },
@@ -4004,7 +4004,7 @@ func init() {
           "type": "array",
           "items": {
             "type": "string",
-            "maxLength": 64
+            "maxLength": 128
           },
           "x-nullable": true
         },
@@ -4105,7 +4105,7 @@ func init() {
           "type": "array",
           "items": {
             "type": "string",
-            "maxLength": 64
+            "maxLength": 128
           }
         },
         "visibility": {
@@ -4182,7 +4182,7 @@ func init() {
     "not-tags": {
       "type": "array",
       "items": {
-        "maxLength": 64,
+        "maxLength": 128,
         "type": "string"
       },
       "description": "Filter for resources not having tags, multiple not-tags are considered as logical AND.\nShould be provided in a comma separated list.\n",
@@ -4192,7 +4192,7 @@ func init() {
     "not-tags-any": {
       "type": "array",
       "items": {
-        "maxLength": 64,
+        "maxLength": 128,
         "type": "string"
       },
       "description": "Filter for resources not having tags, multiple tags are considered as logical OR.\nShould be provided in a comma separated list.\n",
@@ -4223,7 +4223,7 @@ func init() {
     "tags": {
       "type": "array",
       "items": {
-        "maxLength": 64,
+        "maxLength": 128,
         "type": "string"
       },
       "description": "Filter for tags, multiple tags are considered as logical AND.\nShould be provided in a comma separated list.\n",
@@ -4233,7 +4233,7 @@ func init() {
     "tags-any": {
       "type": "array",
       "items": {
-        "maxLength": 64,
+        "maxLength": 128,
         "type": "string"
       },
       "description": "Filter for tags, multiple tags are considered as logical OR.\nShould be provided in a comma separated list.\n",

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -610,6 +610,8 @@ func init() {
       },
       "parameters": [
         {
+          "maxLength": 32,
+          "minLength": 32,
           "type": "string",
           "description": "The ID of the project to query.",
           "name": "project_id",
@@ -1616,6 +1618,8 @@ func init() {
         "target": {
           "description": "The ID of the project to which the RBAC policy will be enforced.",
           "type": "string",
+          "maxLength": 32,
+          "minLength": 32,
           "example": "666da95112694b37b3efb0913de3f499"
         },
         "target_type": {
@@ -1649,6 +1653,8 @@ func init() {
         "target": {
           "description": "The ID of the project to which the RBAC policy will be enforced.",
           "type": "string",
+          "maxLength": 32,
+          "minLength": 32,
           "example": "666da95112694b37b3efb0913de3f499"
         },
         "target_type": {
@@ -1672,6 +1678,7 @@ func init() {
         "availability_zone": {
           "description": "Availability zone of this service.",
           "type": "string",
+          "maxLength": 64,
           "x-nullable": true,
           "x-omitempty": false,
           "example": "AZ-A"
@@ -1706,6 +1713,7 @@ func init() {
         "host": {
           "description": "Device host.",
           "type": "string",
+          "maxLength": 64,
           "x-nullable": true,
           "readOnly": true
         },
@@ -1954,6 +1962,7 @@ func init() {
   },
   "parameters": {
     "limit": {
+      "minimum": 1,
       "type": "integer",
       "description": "Sets the page size.",
       "name": "limit",
@@ -1969,6 +1978,7 @@ func init() {
     "not-tags": {
       "type": "array",
       "items": {
+        "maxLength": 64,
         "type": "string"
       },
       "description": "Filter for resources not having tags, multiple not-tags are considered as logical AND.\nShould be provided in a comma separated list.\n",
@@ -1978,6 +1988,7 @@ func init() {
     "not-tags-any": {
       "type": "array",
       "items": {
+        "maxLength": 64,
         "type": "string"
       },
       "description": "Filter for resources not having tags, multiple tags are considered as logical OR.\nShould be provided in a comma separated list.\n",
@@ -1999,6 +2010,7 @@ func init() {
       "in": "query"
     },
     "sort": {
+      "maxLength": 256,
       "type": "string",
       "description": "Comma-separated list of sort keys, optionally prefix with - to reverse sort order.",
       "name": "sort",
@@ -2007,6 +2019,7 @@ func init() {
     "tags": {
       "type": "array",
       "items": {
+        "maxLength": 64,
         "type": "string"
       },
       "description": "Filter for tags, multiple tags are considered as logical AND.\nShould be provided in a comma separated list.\n",
@@ -2016,6 +2029,7 @@ func init() {
     "tags-any": {
       "type": "array",
       "items": {
+        "maxLength": 64,
         "type": "string"
       },
       "description": "Filter for tags, multiple tags are considered as logical OR.\nShould be provided in a comma separated list.\n",
@@ -2128,12 +2142,14 @@ func init() {
             "in": "query"
           },
           {
+            "minimum": 1,
             "type": "integer",
             "description": "Sets the page size.",
             "name": "limit",
             "in": "query"
           },
           {
+            "maxLength": 256,
             "type": "string",
             "description": "Comma-separated list of sort keys, optionally prefix with - to reverse sort order.",
             "name": "sort",
@@ -2148,6 +2164,7 @@ func init() {
           {
             "type": "array",
             "items": {
+              "maxLength": 64,
               "type": "string"
             },
             "description": "Filter for tags, multiple tags are considered as logical AND.\nShould be provided in a comma separated list.\n",
@@ -2157,6 +2174,7 @@ func init() {
           {
             "type": "array",
             "items": {
+              "maxLength": 64,
               "type": "string"
             },
             "description": "Filter for tags, multiple tags are considered as logical OR.\nShould be provided in a comma separated list.\n",
@@ -2166,6 +2184,7 @@ func init() {
           {
             "type": "array",
             "items": {
+              "maxLength": 64,
               "type": "string"
             },
             "description": "Filter for resources not having tags, multiple not-tags are considered as logical AND.\nShould be provided in a comma separated list.\n",
@@ -2175,6 +2194,7 @@ func init() {
           {
             "type": "array",
             "items": {
+              "maxLength": 64,
               "type": "string"
             },
             "description": "Filter for resources not having tags, multiple tags are considered as logical OR.\nShould be provided in a comma separated list.\n",
@@ -2669,6 +2689,8 @@ func init() {
       },
       "parameters": [
         {
+          "maxLength": 32,
+          "minLength": 32,
           "type": "string",
           "description": "The ID of the project to query.",
           "name": "project_id",
@@ -2692,12 +2714,14 @@ func init() {
             "in": "query"
           },
           {
+            "minimum": 1,
             "type": "integer",
             "description": "Sets the page size.",
             "name": "limit",
             "in": "query"
           },
           {
+            "maxLength": 256,
             "type": "string",
             "description": "Comma-separated list of sort keys, optionally prefix with - to reverse sort order.",
             "name": "sort",
@@ -2963,12 +2987,14 @@ func init() {
             "in": "query"
           },
           {
+            "minimum": 1,
             "type": "integer",
             "description": "Sets the page size.",
             "name": "limit",
             "in": "query"
           },
           {
+            "maxLength": 256,
             "type": "string",
             "description": "Comma-separated list of sort keys, optionally prefix with - to reverse sort order.",
             "name": "sort",
@@ -2983,6 +3009,7 @@ func init() {
           {
             "type": "array",
             "items": {
+              "maxLength": 64,
               "type": "string"
             },
             "description": "Filter for tags, multiple tags are considered as logical AND.\nShould be provided in a comma separated list.\n",
@@ -2992,6 +3019,7 @@ func init() {
           {
             "type": "array",
             "items": {
+              "maxLength": 64,
               "type": "string"
             },
             "description": "Filter for tags, multiple tags are considered as logical OR.\nShould be provided in a comma separated list.\n",
@@ -3001,6 +3029,7 @@ func init() {
           {
             "type": "array",
             "items": {
+              "maxLength": 64,
               "type": "string"
             },
             "description": "Filter for resources not having tags, multiple not-tags are considered as logical AND.\nShould be provided in a comma separated list.\n",
@@ -3010,6 +3039,7 @@ func init() {
           {
             "type": "array",
             "items": {
+              "maxLength": 64,
               "type": "string"
             },
             "description": "Filter for resources not having tags, multiple tags are considered as logical OR.\nShould be provided in a comma separated list.\n",
@@ -3355,12 +3385,14 @@ func init() {
             "in": "query"
           },
           {
+            "minimum": 1,
             "type": "integer",
             "description": "Sets the page size.",
             "name": "limit",
             "in": "query"
           },
           {
+            "maxLength": 256,
             "type": "string",
             "description": "Comma-separated list of sort keys, optionally prefix with - to reverse sort order.",
             "name": "sort",
@@ -3789,6 +3821,8 @@ func init() {
         "target": {
           "description": "The ID of the project to which the RBAC policy will be enforced.",
           "type": "string",
+          "maxLength": 32,
+          "minLength": 32,
           "example": "666da95112694b37b3efb0913de3f499"
         },
         "target_type": {
@@ -3822,6 +3856,8 @@ func init() {
         "target": {
           "description": "The ID of the project to which the RBAC policy will be enforced.",
           "type": "string",
+          "maxLength": 32,
+          "minLength": 32,
           "example": "666da95112694b37b3efb0913de3f499"
         },
         "target_type": {
@@ -3845,6 +3881,7 @@ func init() {
         "availability_zone": {
           "description": "Availability zone of this service.",
           "type": "string",
+          "maxLength": 64,
           "x-nullable": true,
           "x-omitempty": false,
           "example": "AZ-A"
@@ -3879,6 +3916,7 @@ func init() {
         "host": {
           "description": "Device host.",
           "type": "string",
+          "maxLength": 64,
           "x-nullable": true,
           "readOnly": true
         },
@@ -4128,6 +4166,7 @@ func init() {
   },
   "parameters": {
     "limit": {
+      "minimum": 1,
       "type": "integer",
       "description": "Sets the page size.",
       "name": "limit",
@@ -4143,6 +4182,7 @@ func init() {
     "not-tags": {
       "type": "array",
       "items": {
+        "maxLength": 64,
         "type": "string"
       },
       "description": "Filter for resources not having tags, multiple not-tags are considered as logical AND.\nShould be provided in a comma separated list.\n",
@@ -4152,6 +4192,7 @@ func init() {
     "not-tags-any": {
       "type": "array",
       "items": {
+        "maxLength": 64,
         "type": "string"
       },
       "description": "Filter for resources not having tags, multiple tags are considered as logical OR.\nShould be provided in a comma separated list.\n",
@@ -4173,6 +4214,7 @@ func init() {
       "in": "query"
     },
     "sort": {
+      "maxLength": 256,
       "type": "string",
       "description": "Comma-separated list of sort keys, optionally prefix with - to reverse sort order.",
       "name": "sort",
@@ -4181,6 +4223,7 @@ func init() {
     "tags": {
       "type": "array",
       "items": {
+        "maxLength": 64,
         "type": "string"
       },
       "description": "Filter for tags, multiple tags are considered as logical AND.\nShould be provided in a comma separated list.\n",
@@ -4190,6 +4233,7 @@ func init() {
     "tags-any": {
       "type": "array",
       "items": {
+        "maxLength": 64,
         "type": "string"
       },
       "description": "Filter for tags, multiple tags are considered as logical OR.\nShould be provided in a comma separated list.\n",

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -445,8 +445,7 @@ func init() {
       },
       "parameters": [
         {
-          "maxLength": 32,
-          "minLength": 32,
+          "maxLength": 36,
           "type": "string",
           "description": "The ID of the project to query.",
           "name": "project_id",
@@ -610,8 +609,7 @@ func init() {
       },
       "parameters": [
         {
-          "maxLength": 32,
-          "minLength": 32,
+          "maxLength": 36,
           "type": "string",
           "description": "The ID of the project to query.",
           "name": "project_id",
@@ -1549,8 +1547,7 @@ func init() {
     "Project": {
       "description": "The ID of the project owning this resource.",
       "type": "string",
-      "maxLength": 32,
-      "minLength": 32,
+      "maxLength": 36,
       "x-omitempty": false,
       "example": "fa84c217f361441986a220edf9b1e337"
     },
@@ -1618,8 +1615,7 @@ func init() {
         "target": {
           "description": "The ID of the project to which the RBAC policy will be enforced.",
           "type": "string",
-          "maxLength": 32,
-          "minLength": 32,
+          "maxLength": 36,
           "example": "666da95112694b37b3efb0913de3f499"
         },
         "target_type": {
@@ -1653,8 +1649,7 @@ func init() {
         "target": {
           "description": "The ID of the project to which the RBAC policy will be enforced.",
           "type": "string",
-          "maxLength": 32,
-          "minLength": 32,
+          "maxLength": 36,
           "example": "666da95112694b37b3efb0913de3f499"
         },
         "target_type": {
@@ -2002,8 +1997,7 @@ func init() {
       "in": "query"
     },
     "project_id": {
-      "maxLength": 32,
-      "minLength": 32,
+      "maxLength": 36,
       "type": "string",
       "description": "Filter for resources belonging or accessible by a specific project.\n",
       "name": "project_id",
@@ -2202,8 +2196,7 @@ func init() {
             "in": "query"
           },
           {
-            "maxLength": 32,
-            "minLength": 32,
+            "maxLength": 36,
             "type": "string",
             "description": "Filter for resources belonging or accessible by a specific project.\n",
             "name": "project_id",
@@ -2524,8 +2517,7 @@ func init() {
       },
       "parameters": [
         {
-          "maxLength": 32,
-          "minLength": 32,
+          "maxLength": 36,
           "type": "string",
           "description": "The ID of the project to query.",
           "name": "project_id",
@@ -2689,8 +2681,7 @@ func init() {
       },
       "parameters": [
         {
-          "maxLength": 32,
-          "minLength": 32,
+          "maxLength": 36,
           "type": "string",
           "description": "The ID of the project to query.",
           "name": "project_id",
@@ -3047,8 +3038,7 @@ func init() {
             "in": "query"
           },
           {
-            "maxLength": 32,
-            "minLength": 32,
+            "maxLength": 36,
             "type": "string",
             "description": "Filter for resources belonging or accessible by a specific project.\n",
             "name": "project_id",
@@ -3734,8 +3724,7 @@ func init() {
     "Project": {
       "description": "The ID of the project owning this resource.",
       "type": "string",
-      "maxLength": 32,
-      "minLength": 32,
+      "maxLength": 36,
       "x-omitempty": false,
       "example": "fa84c217f361441986a220edf9b1e337"
     },
@@ -3821,8 +3810,7 @@ func init() {
         "target": {
           "description": "The ID of the project to which the RBAC policy will be enforced.",
           "type": "string",
-          "maxLength": 32,
-          "minLength": 32,
+          "maxLength": 36,
           "example": "666da95112694b37b3efb0913de3f499"
         },
         "target_type": {
@@ -3856,8 +3844,7 @@ func init() {
         "target": {
           "description": "The ID of the project to which the RBAC policy will be enforced.",
           "type": "string",
-          "maxLength": 32,
-          "minLength": 32,
+          "maxLength": 36,
           "example": "666da95112694b37b3efb0913de3f499"
         },
         "target_type": {
@@ -4206,8 +4193,7 @@ func init() {
       "in": "query"
     },
     "project_id": {
-      "maxLength": 32,
-      "minLength": 32,
+      "maxLength": 36,
       "type": "string",
       "description": "Filter for resources belonging or accessible by a specific project.\n",
       "name": "project_id",

--- a/restapi/operations/endpoint/get_endpoint_parameters.go
+++ b/restapi/operations/endpoint/get_endpoint_parameters.go
@@ -81,8 +81,7 @@ type GetEndpointParams struct {
 
 	/*Filter for resources belonging or accessible by a specific project.
 
-	  Max Length: 32
-	  Min Length: 32
+	  Max Length: 36
 	  In: query
 	*/
 	ProjectID *string
@@ -352,11 +351,7 @@ func (o *GetEndpointParams) bindProjectID(rawData []string, hasKey bool, formats
 // validateProjectID carries out validations for parameter ProjectID
 func (o *GetEndpointParams) validateProjectID(formats strfmt.Registry) error {
 
-	if err := validate.MinLength("project_id", "query", *o.ProjectID, 32); err != nil {
-		return err
-	}
-
-	if err := validate.MaxLength("project_id", "query", *o.ProjectID, 32); err != nil {
+	if err := validate.MaxLength("project_id", "query", *o.ProjectID, 36); err != nil {
 		return err
 	}
 

--- a/restapi/operations/endpoint/get_endpoint_parameters.go
+++ b/restapi/operations/endpoint/get_endpoint_parameters.go
@@ -22,6 +22,7 @@ package endpoint
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-openapi/errors"
@@ -49,6 +50,7 @@ type GetEndpointParams struct {
 	HTTPRequest *http.Request `json:"-"`
 
 	/*Sets the page size.
+	  Minimum: 1
 	  In: query
 	*/
 	Limit *int64
@@ -86,6 +88,7 @@ type GetEndpointParams struct {
 	ProjectID *string
 
 	/*Comma-separated list of sort keys, optionally prefix with - to reverse sort order.
+	  Max Length: 256
 	  In: query
 	*/
 	Sort *string
@@ -185,6 +188,20 @@ func (o *GetEndpointParams) bindLimit(rawData []string, hasKey bool, formats str
 	}
 	o.Limit = &value
 
+	if err := o.validateLimit(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateLimit carries out validations for parameter Limit
+func (o *GetEndpointParams) validateLimit(formats strfmt.Registry) error {
+
+	if err := validate.MinimumInt("limit", "query", *o.Limit, 1, false); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -241,8 +258,12 @@ func (o *GetEndpointParams) bindNotTags(rawData []string, hasKey bool, formats s
 	}
 
 	var notTagsIR []string
-	for _, notTagsIV := range notTagsIC {
+	for i, notTagsIV := range notTagsIC {
 		notTagsI := notTagsIV
+
+		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "not-tags", i), "query", notTagsI, 64); err != nil {
+			return err
+		}
 
 		notTagsIR = append(notTagsIR, notTagsI)
 	}
@@ -268,8 +289,12 @@ func (o *GetEndpointParams) bindNotTagsAny(rawData []string, hasKey bool, format
 	}
 
 	var notTagsAnyIR []string
-	for _, notTagsAnyIV := range notTagsAnyIC {
+	for i, notTagsAnyIV := range notTagsAnyIC {
 		notTagsAnyI := notTagsAnyIV
+
+		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "not-tags-any", i), "query", notTagsAnyI, 64); err != nil {
+			return err
+		}
 
 		notTagsAnyIR = append(notTagsAnyIR, notTagsAnyI)
 	}
@@ -353,6 +378,20 @@ func (o *GetEndpointParams) bindSort(rawData []string, hasKey bool, formats strf
 	}
 	o.Sort = &raw
 
+	if err := o.validateSort(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateSort carries out validations for parameter Sort
+func (o *GetEndpointParams) validateSort(formats strfmt.Registry) error {
+
+	if err := validate.MaxLength("sort", "query", *o.Sort, 256); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -372,8 +411,12 @@ func (o *GetEndpointParams) bindTags(rawData []string, hasKey bool, formats strf
 	}
 
 	var tagsIR []string
-	for _, tagsIV := range tagsIC {
+	for i, tagsIV := range tagsIC {
 		tagsI := tagsIV
+
+		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "tags", i), "query", tagsI, 64); err != nil {
+			return err
+		}
 
 		tagsIR = append(tagsIR, tagsI)
 	}
@@ -399,8 +442,12 @@ func (o *GetEndpointParams) bindTagsAny(rawData []string, hasKey bool, formats s
 	}
 
 	var tagsAnyIR []string
-	for _, tagsAnyIV := range tagsAnyIC {
+	for i, tagsAnyIV := range tagsAnyIC {
 		tagsAnyI := tagsAnyIV
+
+		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "tags-any", i), "query", tagsAnyI, 64); err != nil {
+			return err
+		}
 
 		tagsAnyIR = append(tagsAnyIR, tagsAnyI)
 	}

--- a/restapi/operations/endpoint/get_endpoint_parameters.go
+++ b/restapi/operations/endpoint/get_endpoint_parameters.go
@@ -261,7 +261,7 @@ func (o *GetEndpointParams) bindNotTags(rawData []string, hasKey bool, formats s
 	for i, notTagsIV := range notTagsIC {
 		notTagsI := notTagsIV
 
-		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "not-tags", i), "query", notTagsI, 64); err != nil {
+		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "not-tags", i), "query", notTagsI, 128); err != nil {
 			return err
 		}
 
@@ -292,7 +292,7 @@ func (o *GetEndpointParams) bindNotTagsAny(rawData []string, hasKey bool, format
 	for i, notTagsAnyIV := range notTagsAnyIC {
 		notTagsAnyI := notTagsAnyIV
 
-		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "not-tags-any", i), "query", notTagsAnyI, 64); err != nil {
+		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "not-tags-any", i), "query", notTagsAnyI, 128); err != nil {
 			return err
 		}
 
@@ -414,7 +414,7 @@ func (o *GetEndpointParams) bindTags(rawData []string, hasKey bool, formats strf
 	for i, tagsIV := range tagsIC {
 		tagsI := tagsIV
 
-		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "tags", i), "query", tagsI, 64); err != nil {
+		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "tags", i), "query", tagsI, 128); err != nil {
 			return err
 		}
 
@@ -445,7 +445,7 @@ func (o *GetEndpointParams) bindTagsAny(rawData []string, hasKey bool, formats s
 	for i, tagsAnyIV := range tagsAnyIC {
 		tagsAnyI := tagsAnyIV
 
-		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "tags-any", i), "query", tagsAnyI, 64); err != nil {
+		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "tags-any", i), "query", tagsAnyI, 128); err != nil {
 			return err
 		}
 

--- a/restapi/operations/endpoint/put_endpoint_endpoint_id.go
+++ b/restapi/operations/endpoint/put_endpoint_endpoint_id.go
@@ -163,7 +163,7 @@ func (o *PutEndpointEndpointIDBody) validateTags(formats strfmt.Registry) error 
 
 	for i := 0; i < len(o.Tags); i++ {
 
-		if err := validate.MaxLength("body"+"."+"tags"+"."+strconv.Itoa(i), "body", o.Tags[i], 64); err != nil {
+		if err := validate.MaxLength("body"+"."+"tags"+"."+strconv.Itoa(i), "body", o.Tags[i], 128); err != nil {
 			return err
 		}
 

--- a/restapi/operations/quota/delete_quotas_project_id_parameters.go
+++ b/restapi/operations/quota/delete_quotas_project_id_parameters.go
@@ -27,6 +27,7 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
 )
 
 // NewDeleteQuotasProjectIDParams creates a new DeleteQuotasProjectIDParams object
@@ -47,6 +48,8 @@ type DeleteQuotasProjectIDParams struct {
 
 	/*The ID of the project to query.
 	  Required: true
+	  Max Length: 32
+	  Min Length: 32
 	  In: path
 	*/
 	ProjectID string
@@ -81,6 +84,24 @@ func (o *DeleteQuotasProjectIDParams) bindProjectID(rawData []string, hasKey boo
 	// Required: true
 	// Parameter is provided by construction from the route
 	o.ProjectID = raw
+
+	if err := o.validateProjectID(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateProjectID carries out validations for parameter ProjectID
+func (o *DeleteQuotasProjectIDParams) validateProjectID(formats strfmt.Registry) error {
+
+	if err := validate.MinLength("project_id", "path", o.ProjectID, 32); err != nil {
+		return err
+	}
+
+	if err := validate.MaxLength("project_id", "path", o.ProjectID, 32); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/restapi/operations/quota/delete_quotas_project_id_parameters.go
+++ b/restapi/operations/quota/delete_quotas_project_id_parameters.go
@@ -48,8 +48,7 @@ type DeleteQuotasProjectIDParams struct {
 
 	/*The ID of the project to query.
 	  Required: true
-	  Max Length: 32
-	  Min Length: 32
+	  Max Length: 36
 	  In: path
 	*/
 	ProjectID string
@@ -95,11 +94,7 @@ func (o *DeleteQuotasProjectIDParams) bindProjectID(rawData []string, hasKey boo
 // validateProjectID carries out validations for parameter ProjectID
 func (o *DeleteQuotasProjectIDParams) validateProjectID(formats strfmt.Registry) error {
 
-	if err := validate.MinLength("project_id", "path", o.ProjectID, 32); err != nil {
-		return err
-	}
-
-	if err := validate.MaxLength("project_id", "path", o.ProjectID, 32); err != nil {
+	if err := validate.MaxLength("project_id", "path", o.ProjectID, 36); err != nil {
 		return err
 	}
 

--- a/restapi/operations/quota/get_quotas_parameters.go
+++ b/restapi/operations/quota/get_quotas_parameters.go
@@ -48,8 +48,7 @@ type GetQuotasParams struct {
 	HTTPRequest *http.Request `json:"-"`
 
 	/*The ID of the project to query.
-	  Max Length: 32
-	  Min Length: 32
+	  Max Length: 36
 	  In: query
 	*/
 	ProjectID *string
@@ -100,11 +99,7 @@ func (o *GetQuotasParams) bindProjectID(rawData []string, hasKey bool, formats s
 // validateProjectID carries out validations for parameter ProjectID
 func (o *GetQuotasParams) validateProjectID(formats strfmt.Registry) error {
 
-	if err := validate.MinLength("project_id", "query", *o.ProjectID, 32); err != nil {
-		return err
-	}
-
-	if err := validate.MaxLength("project_id", "query", *o.ProjectID, 32); err != nil {
+	if err := validate.MaxLength("project_id", "query", *o.ProjectID, 36); err != nil {
 		return err
 	}
 

--- a/restapi/operations/quota/get_quotas_project_id_parameters.go
+++ b/restapi/operations/quota/get_quotas_project_id_parameters.go
@@ -48,8 +48,7 @@ type GetQuotasProjectIDParams struct {
 
 	/*The ID of the project to query.
 	  Required: true
-	  Max Length: 32
-	  Min Length: 32
+	  Max Length: 36
 	  In: path
 	*/
 	ProjectID string
@@ -95,11 +94,7 @@ func (o *GetQuotasProjectIDParams) bindProjectID(rawData []string, hasKey bool, 
 // validateProjectID carries out validations for parameter ProjectID
 func (o *GetQuotasProjectIDParams) validateProjectID(formats strfmt.Registry) error {
 
-	if err := validate.MinLength("project_id", "path", o.ProjectID, 32); err != nil {
-		return err
-	}
-
-	if err := validate.MaxLength("project_id", "path", o.ProjectID, 32); err != nil {
+	if err := validate.MaxLength("project_id", "path", o.ProjectID, 36); err != nil {
 		return err
 	}
 

--- a/restapi/operations/quota/get_quotas_project_id_parameters.go
+++ b/restapi/operations/quota/get_quotas_project_id_parameters.go
@@ -27,6 +27,7 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
 )
 
 // NewGetQuotasProjectIDParams creates a new GetQuotasProjectIDParams object
@@ -47,6 +48,8 @@ type GetQuotasProjectIDParams struct {
 
 	/*The ID of the project to query.
 	  Required: true
+	  Max Length: 32
+	  Min Length: 32
 	  In: path
 	*/
 	ProjectID string
@@ -81,6 +84,24 @@ func (o *GetQuotasProjectIDParams) bindProjectID(rawData []string, hasKey bool, 
 	// Required: true
 	// Parameter is provided by construction from the route
 	o.ProjectID = raw
+
+	if err := o.validateProjectID(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateProjectID carries out validations for parameter ProjectID
+func (o *GetQuotasProjectIDParams) validateProjectID(formats strfmt.Registry) error {
+
+	if err := validate.MinLength("project_id", "path", o.ProjectID, 32); err != nil {
+		return err
+	}
+
+	if err := validate.MaxLength("project_id", "path", o.ProjectID, 32); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/restapi/operations/quota/put_quotas_project_id_parameters.go
+++ b/restapi/operations/quota/put_quotas_project_id_parameters.go
@@ -59,8 +59,7 @@ type PutQuotasProjectIDParams struct {
 
 	/*The ID of the project to query.
 	  Required: true
-	  Max Length: 32
-	  Min Length: 32
+	  Max Length: 36
 	  In: path
 	*/
 	ProjectID string
@@ -136,11 +135,7 @@ func (o *PutQuotasProjectIDParams) bindProjectID(rawData []string, hasKey bool, 
 // validateProjectID carries out validations for parameter ProjectID
 func (o *PutQuotasProjectIDParams) validateProjectID(formats strfmt.Registry) error {
 
-	if err := validate.MinLength("project_id", "path", o.ProjectID, 32); err != nil {
-		return err
-	}
-
-	if err := validate.MaxLength("project_id", "path", o.ProjectID, 32); err != nil {
+	if err := validate.MaxLength("project_id", "path", o.ProjectID, 36); err != nil {
 		return err
 	}
 

--- a/restapi/operations/quota/put_quotas_project_id_parameters.go
+++ b/restapi/operations/quota/put_quotas_project_id_parameters.go
@@ -59,6 +59,8 @@ type PutQuotasProjectIDParams struct {
 
 	/*The ID of the project to query.
 	  Required: true
+	  Max Length: 32
+	  Min Length: 32
 	  In: path
 	*/
 	ProjectID string
@@ -123,6 +125,24 @@ func (o *PutQuotasProjectIDParams) bindProjectID(rawData []string, hasKey bool, 
 	// Required: true
 	// Parameter is provided by construction from the route
 	o.ProjectID = raw
+
+	if err := o.validateProjectID(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateProjectID carries out validations for parameter ProjectID
+func (o *PutQuotasProjectIDParams) validateProjectID(formats strfmt.Registry) error {
+
+	if err := validate.MinLength("project_id", "path", o.ProjectID, 32); err != nil {
+		return err
+	}
+
+	if err := validate.MaxLength("project_id", "path", o.ProjectID, 32); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/restapi/operations/rbac/get_rbac_policies_parameters.go
+++ b/restapi/operations/rbac/get_rbac_policies_parameters.go
@@ -49,6 +49,7 @@ type GetRbacPoliciesParams struct {
 	HTTPRequest *http.Request `json:"-"`
 
 	/*Sets the page size.
+	  Minimum: 1
 	  In: query
 	*/
 	Limit *int64
@@ -64,6 +65,7 @@ type GetRbacPoliciesParams struct {
 	PageReverse *bool
 
 	/*Comma-separated list of sort keys, optionally prefix with - to reverse sort order.
+	  Max Length: 256
 	  In: query
 	*/
 	Sort *string
@@ -123,6 +125,20 @@ func (o *GetRbacPoliciesParams) bindLimit(rawData []string, hasKey bool, formats
 		return errors.InvalidType("limit", "query", "int64", raw)
 	}
 	o.Limit = &value
+
+	if err := o.validateLimit(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateLimit carries out validations for parameter Limit
+func (o *GetRbacPoliciesParams) validateLimit(formats strfmt.Registry) error {
+
+	if err := validate.MinimumInt("limit", "query", *o.Limit, 1, false); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -201,6 +217,20 @@ func (o *GetRbacPoliciesParams) bindSort(rawData []string, hasKey bool, formats 
 		return nil
 	}
 	o.Sort = &raw
+
+	if err := o.validateSort(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateSort carries out validations for parameter Sort
+func (o *GetRbacPoliciesParams) validateSort(formats strfmt.Registry) error {
+
+	if err := validate.MaxLength("sort", "query", *o.Sort, 256); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/restapi/operations/service/get_service_parameters.go
+++ b/restapi/operations/service/get_service_parameters.go
@@ -261,7 +261,7 @@ func (o *GetServiceParams) bindNotTags(rawData []string, hasKey bool, formats st
 	for i, notTagsIV := range notTagsIC {
 		notTagsI := notTagsIV
 
-		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "not-tags", i), "query", notTagsI, 64); err != nil {
+		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "not-tags", i), "query", notTagsI, 128); err != nil {
 			return err
 		}
 
@@ -292,7 +292,7 @@ func (o *GetServiceParams) bindNotTagsAny(rawData []string, hasKey bool, formats
 	for i, notTagsAnyIV := range notTagsAnyIC {
 		notTagsAnyI := notTagsAnyIV
 
-		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "not-tags-any", i), "query", notTagsAnyI, 64); err != nil {
+		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "not-tags-any", i), "query", notTagsAnyI, 128); err != nil {
 			return err
 		}
 
@@ -414,7 +414,7 @@ func (o *GetServiceParams) bindTags(rawData []string, hasKey bool, formats strfm
 	for i, tagsIV := range tagsIC {
 		tagsI := tagsIV
 
-		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "tags", i), "query", tagsI, 64); err != nil {
+		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "tags", i), "query", tagsI, 128); err != nil {
 			return err
 		}
 
@@ -445,7 +445,7 @@ func (o *GetServiceParams) bindTagsAny(rawData []string, hasKey bool, formats st
 	for i, tagsAnyIV := range tagsAnyIC {
 		tagsAnyI := tagsAnyIV
 
-		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "tags-any", i), "query", tagsAnyI, 64); err != nil {
+		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "tags-any", i), "query", tagsAnyI, 128); err != nil {
 			return err
 		}
 

--- a/restapi/operations/service/get_service_parameters.go
+++ b/restapi/operations/service/get_service_parameters.go
@@ -22,6 +22,7 @@ package service
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-openapi/errors"
@@ -49,6 +50,7 @@ type GetServiceParams struct {
 	HTTPRequest *http.Request `json:"-"`
 
 	/*Sets the page size.
+	  Minimum: 1
 	  In: query
 	*/
 	Limit *int64
@@ -86,6 +88,7 @@ type GetServiceParams struct {
 	ProjectID *string
 
 	/*Comma-separated list of sort keys, optionally prefix with - to reverse sort order.
+	  Max Length: 256
 	  In: query
 	*/
 	Sort *string
@@ -185,6 +188,20 @@ func (o *GetServiceParams) bindLimit(rawData []string, hasKey bool, formats strf
 	}
 	o.Limit = &value
 
+	if err := o.validateLimit(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateLimit carries out validations for parameter Limit
+func (o *GetServiceParams) validateLimit(formats strfmt.Registry) error {
+
+	if err := validate.MinimumInt("limit", "query", *o.Limit, 1, false); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -241,8 +258,12 @@ func (o *GetServiceParams) bindNotTags(rawData []string, hasKey bool, formats st
 	}
 
 	var notTagsIR []string
-	for _, notTagsIV := range notTagsIC {
+	for i, notTagsIV := range notTagsIC {
 		notTagsI := notTagsIV
+
+		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "not-tags", i), "query", notTagsI, 64); err != nil {
+			return err
+		}
 
 		notTagsIR = append(notTagsIR, notTagsI)
 	}
@@ -268,8 +289,12 @@ func (o *GetServiceParams) bindNotTagsAny(rawData []string, hasKey bool, formats
 	}
 
 	var notTagsAnyIR []string
-	for _, notTagsAnyIV := range notTagsAnyIC {
+	for i, notTagsAnyIV := range notTagsAnyIC {
 		notTagsAnyI := notTagsAnyIV
+
+		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "not-tags-any", i), "query", notTagsAnyI, 64); err != nil {
+			return err
+		}
 
 		notTagsAnyIR = append(notTagsAnyIR, notTagsAnyI)
 	}
@@ -353,6 +378,20 @@ func (o *GetServiceParams) bindSort(rawData []string, hasKey bool, formats strfm
 	}
 	o.Sort = &raw
 
+	if err := o.validateSort(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateSort carries out validations for parameter Sort
+func (o *GetServiceParams) validateSort(formats strfmt.Registry) error {
+
+	if err := validate.MaxLength("sort", "query", *o.Sort, 256); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -372,8 +411,12 @@ func (o *GetServiceParams) bindTags(rawData []string, hasKey bool, formats strfm
 	}
 
 	var tagsIR []string
-	for _, tagsIV := range tagsIC {
+	for i, tagsIV := range tagsIC {
 		tagsI := tagsIV
+
+		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "tags", i), "query", tagsI, 64); err != nil {
+			return err
+		}
 
 		tagsIR = append(tagsIR, tagsI)
 	}
@@ -399,8 +442,12 @@ func (o *GetServiceParams) bindTagsAny(rawData []string, hasKey bool, formats st
 	}
 
 	var tagsAnyIR []string
-	for _, tagsAnyIV := range tagsAnyIC {
+	for i, tagsAnyIV := range tagsAnyIC {
 		tagsAnyI := tagsAnyIV
+
+		if err := validate.MaxLength(fmt.Sprintf("%s.%v", "tags-any", i), "query", tagsAnyI, 64); err != nil {
+			return err
+		}
 
 		tagsAnyIR = append(tagsAnyIR, tagsAnyI)
 	}

--- a/restapi/operations/service/get_service_parameters.go
+++ b/restapi/operations/service/get_service_parameters.go
@@ -81,8 +81,7 @@ type GetServiceParams struct {
 
 	/*Filter for resources belonging or accessible by a specific project.
 
-	  Max Length: 32
-	  Min Length: 32
+	  Max Length: 36
 	  In: query
 	*/
 	ProjectID *string
@@ -352,11 +351,7 @@ func (o *GetServiceParams) bindProjectID(rawData []string, hasKey bool, formats 
 // validateProjectID carries out validations for parameter ProjectID
 func (o *GetServiceParams) validateProjectID(formats strfmt.Registry) error {
 
-	if err := validate.MinLength("project_id", "query", *o.ProjectID, 32); err != nil {
-		return err
-	}
-
-	if err := validate.MaxLength("project_id", "query", *o.ProjectID, 32); err != nil {
+	if err := validate.MaxLength("project_id", "query", *o.ProjectID, 36); err != nil {
 		return err
 	}
 

--- a/restapi/operations/service/get_service_service_id_endpoints_parameters.go
+++ b/restapi/operations/service/get_service_service_id_endpoints_parameters.go
@@ -49,6 +49,7 @@ type GetServiceServiceIDEndpointsParams struct {
 	HTTPRequest *http.Request `json:"-"`
 
 	/*Sets the page size.
+	  Minimum: 1
 	  In: query
 	*/
 	Limit *int64
@@ -70,6 +71,7 @@ type GetServiceServiceIDEndpointsParams struct {
 	ServiceID strfmt.UUID
 
 	/*Comma-separated list of sort keys, optionally prefix with - to reverse sort order.
+	  Max Length: 256
 	  In: query
 	*/
 	Sort *string
@@ -134,6 +136,20 @@ func (o *GetServiceServiceIDEndpointsParams) bindLimit(rawData []string, hasKey 
 		return errors.InvalidType("limit", "query", "int64", raw)
 	}
 	o.Limit = &value
+
+	if err := o.validateLimit(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateLimit carries out validations for parameter Limit
+func (o *GetServiceServiceIDEndpointsParams) validateLimit(formats strfmt.Registry) error {
+
+	if err := validate.MinimumInt("limit", "query", *o.Limit, 1, false); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -245,6 +261,20 @@ func (o *GetServiceServiceIDEndpointsParams) bindSort(rawData []string, hasKey b
 		return nil
 	}
 	o.Sort = &raw
+
+	if err := o.validateSort(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateSort carries out validations for parameter Sort
+func (o *GetServiceServiceIDEndpointsParams) validateSort(formats strfmt.Registry) error {
+
+	if err := validate.MaxLength("sort", "query", *o.Sort, 256); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -665,7 +665,7 @@ paths:
                 x-nullable: true
                 items:
                   type: string
-                  maxLength: 64
+                  maxLength: 128
               name:
                 type: string
                 description: Name of the endpoint.
@@ -1079,7 +1079,7 @@ parameters:
       Should be provided in a comma separated list.
     items:
       type: string
-      maxLength: 64
+      maxLength: 128
   tags-any:
     name: tags-any
     in: query
@@ -1089,7 +1089,7 @@ parameters:
       Should be provided in a comma separated list.
     items:
       type: string
-      maxLength: 64
+      maxLength: 128
   not-tags:
     name: not-tags
     in: query
@@ -1099,7 +1099,7 @@ parameters:
       Should be provided in a comma separated list.
     items:
       type: string
-      maxLength: 64
+      maxLength: 128
   not-tags-any:
     name: not-tags-any
     in: query
@@ -1109,7 +1109,7 @@ parameters:
       Should be provided in a comma separated list.
     items:
       type: string
-      maxLength: 64
+      maxLength: 128
   project_id:
     name: project_id
     in: query
@@ -1209,7 +1209,7 @@ definitions:
         x-nullable: true
         items:
           type: string
-          maxLength: 64
+          maxLength: 128
       provider:
         type: string
         description: Provider type, defaults to tenant type.
@@ -1353,7 +1353,7 @@ definitions:
         description: The list of tags on the resource.
         items:
           type: string
-          maxLength: 64
+          maxLength: 128
   EndpointConsumer:
     type: object
     properties:
@@ -1439,7 +1439,7 @@ definitions:
         x-nullable: true
         items:
           type: string
-          maxLength: 64
+          maxLength: 128
       status:
         $ref: "#/definitions/EndpointStatus"
       created_at:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -896,8 +896,7 @@ paths:
         name: project_id
         type: string
         description: The ID of the project to query.
-        minLength: 32
-        maxLength: 32
+        maxLength: 36
     get:
       tags:
         - Quota
@@ -969,8 +968,7 @@ paths:
         required: true
         type: string
         description: The ID of the project to query.
-        minLength: 32
-        maxLength: 32
+        maxLength: 36
     get:
       tags:
         - Quota
@@ -1116,8 +1114,7 @@ parameters:
     type: string
     description: |
       Filter for resources belonging or accessible by a specific project.
-    minLength: 32
-    maxLength: 32
+    maxLength: 36
 
 definitions:
   Service:
@@ -1494,8 +1491,7 @@ definitions:
         description: The ID of the project to which the RBAC policy will be enforced.
         type: string
         example: 666da95112694b37b3efb0913de3f499
-        minLength: 32
-        maxLength: 32
+        maxLength: 36
       project_id:
         $ref: "#/definitions/Project"
   RBACPolicy:
@@ -1518,8 +1514,7 @@ definitions:
         description: The ID of the project to which the RBAC policy will be enforced.
         type: string
         example: 666da95112694b37b3efb0913de3f499
-        minLength: 32
-        maxLength: 32
+        maxLength: 36
       service_id:
         type: string
         format: uuid
@@ -1551,8 +1546,7 @@ definitions:
     type: string
     description: The ID of the project owning this resource.
     example: fa84c217f361441986a220edf9b1e337
-    minLength: 32
-    maxLength: 32
+    maxLength: 36
     x-omitempty: false
   QuotaUsage:
     type: object

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -969,6 +969,8 @@ paths:
         required: true
         type: string
         description: The ID of the project to query.
+        minLength: 32
+        maxLength: 32
     get:
       tags:
         - Quota
@@ -1056,11 +1058,13 @@ parameters:
     in: query
     type: integer
     description: Sets the page size.
+    minimum: 1
   sort:
     name: sort
     in: query
     type: string
     description: Comma-separated list of sort keys, optionally prefix with - to reverse sort order.
+    maxLength: 256
   page_reverse:
     name: page_reverse
     in: query
@@ -1075,6 +1079,7 @@ parameters:
       Should be provided in a comma separated list.
     items:
       type: string
+      maxLength: 64
   tags-any:
     name: tags-any
     in: query
@@ -1084,6 +1089,7 @@ parameters:
       Should be provided in a comma separated list.
     items:
       type: string
+      maxLength: 64
   not-tags:
     name: not-tags
     in: query
@@ -1093,6 +1099,7 @@ parameters:
       Should be provided in a comma separated list.
     items:
       type: string
+      maxLength: 64
   not-tags-any:
     name: not-tags-any
     in: query
@@ -1102,6 +1109,7 @@ parameters:
       Should be provided in a comma separated list.
     items:
       type: string
+      maxLength: 64
   project_id:
     name: project_id
     in: query
@@ -1182,11 +1190,13 @@ definitions:
         type: string
         description: Availability zone of this service.
         example: AZ-A
+        maxLength: 64
         x-nullable: true
         x-omitempty: false
       host:
         type: string
         description: Device host.
+        maxLength: 64
         readOnly: true
         x-nullable: true
       proxy_protocol:
@@ -1484,6 +1494,8 @@ definitions:
         description: The ID of the project to which the RBAC policy will be enforced.
         type: string
         example: 666da95112694b37b3efb0913de3f499
+        minLength: 32
+        maxLength: 32
       project_id:
         $ref: "#/definitions/Project"
   RBACPolicy:
@@ -1506,6 +1518,8 @@ definitions:
         description: The ID of the project to which the RBAC policy will be enforced.
         type: string
         example: 666da95112694b37b3efb0913de3f499
+        minLength: 32
+        maxLength: 32
       service_id:
         type: string
         format: uuid


### PR DESCRIPTION
- Add validation to swagger wherever possible
- Increase the tag length to 128 since this is very tight for some use cases, e.g., where k8s operator names can be used in the tags.