### PR TITLE
fix(archerctl): use server defaults for boolean flags when not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `--no-proxy-protocol` flag to `service create` and `service set` commands
+
 ### Fixed
 
 - F5 agent: tolerate missing Neutron ports when endpoints are pending deletion/rejection
 - Agent: fix DB notification thread reconnection - properly re-acquire connection when lost
 - Agent: clarify log field names (`job_id`, `endpoint_ids`) for better debugging
+- `service create` no longer defaults `require_approval`, `enabled`, and `proxy_protocol` when flags are not specified; the server defaults now apply
 
 ## [2.2.0] - 2026-04-16
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -84,6 +84,18 @@ func shouldDisableColor(w io.Writer) bool {
 	return true
 }
 
+// boolFlag returns a *bool based on a pair of boolean flags (e.g., --enable/--disable).
+// Returns nil if neither flag is set, allowing the server default to apply.
+func boolFlag(enable, disable bool) *bool {
+	if enable {
+		return new(true)
+	}
+	if disable {
+		return new(false)
+	}
+	return nil
+}
+
 func SetupClient() {
 	Table.SetOutputMirror(os.Stdout)
 

--- a/internal/client/endpoint.go
+++ b/internal/client/endpoint.go
@@ -138,18 +138,12 @@ func (*EndpointCreate) Execute(_ []string) error {
 		subnetID = &id
 	}
 
-	var connectionMirroring *bool
-	if EndpointOptions.EndpointCreate.ConnectionMirroring {
-		t := true
-		connectionMirroring = &t
-	}
-
 	sv := models.Endpoint{
 		Name:                EndpointOptions.EndpointCreate.Name,
 		Description:         EndpointOptions.EndpointCreate.Description,
 		ServiceID:           serviceID,
 		Tags:                EndpointOptions.EndpointCreate.Tags,
-		ConnectionMirroring: connectionMirroring,
+		ConnectionMirroring: boolFlag(EndpointOptions.EndpointCreate.ConnectionMirroring, false),
 		Target: models.EndpointTarget{
 			Network: networkID,
 			Port:    portID,
@@ -233,22 +227,13 @@ func (*EndpointSet) Execute(_ []string) error {
 		tags = append(EndpointOptions.EndpointSet.Tags, resp.Payload.Tags...)
 	}
 
-	var connectionMirroring *bool
-	if EndpointOptions.EndpointSet.ConnectionMirroring {
-		t := true
-		connectionMirroring = &t
-	} else if EndpointOptions.EndpointSet.NoConnectionMirroring {
-		t := false
-		connectionMirroring = &t
-	}
-
 	params := endpoint.
 		NewPutEndpointEndpointIDParams().
 		WithEndpointID(endpointID).
 		WithBody(endpoint.PutEndpointEndpointIDBody{
 			Name:                EndpointOptions.EndpointSet.Name,
 			Description:         EndpointOptions.EndpointSet.Description,
-			ConnectionMirroring: connectionMirroring,
+			ConnectionMirroring: boolFlag(EndpointOptions.EndpointSet.ConnectionMirroring, EndpointOptions.EndpointSet.NoConnectionMirroring),
 			Tags:                tags,
 		})
 	resp, err := ArcherClient.Endpoint.PutEndpointEndpointID(params, nil)

--- a/internal/client/service.go
+++ b/internal/client/service.go
@@ -100,6 +100,7 @@ type ServiceCreate struct {
 	Port              []int32       `long:"port" description:"Port exposed by the service (repeat option to set multiple ports)" required:"true"`
 	Protocol          *string       `long:"protocol" description:"Protocol type of the service" choice:"TCP" choice:"HTTP"`
 	ProxyProtocol     bool          `long:"proxy-protocol" description:"Enable proxy protocol v2."`
+	NoProxyProtocol   bool          `long:"no-proxy-protocol" description:"Disable proxy protocol v2."`
 	RequireApproval   bool          `long:"require-approval" description:"Require explicit project approval for the service owner."`
 	NoRequireApproval bool          `long:"no-require-approval" description:"Disable require approval for the service owner."`
 	Tags              []string      `long:"tag" description:"Tag to be added to the service (repeat option to set multiple tags)"`
@@ -125,20 +126,17 @@ func (*ServiceCreate) Execute(_ []string) error {
 		networkID = &id
 	}
 
-	enabled := ServiceOptions.ServiceCreate.Enable || !ServiceOptions.ServiceCreate.Disable
-	requireApproval := ServiceOptions.ServiceCreate.RequireApproval || !ServiceOptions.ServiceCreate.NoRequireApproval
-
 	sv := models.Service{
 		Name:             ServiceOptions.ServiceCreate.Name,
 		Description:      ServiceOptions.ServiceCreate.Description,
 		Provider:         ServiceOptions.ServiceCreate.Provider,
-		Enabled:          &enabled,
+		Enabled:          boolFlag(ServiceOptions.ServiceCreate.Enable, ServiceOptions.ServiceCreate.Disable),
 		NetworkID:        networkID,
 		IPAddresses:      ServiceOptions.ServiceCreate.IPAddresses,
 		Ports:            ServiceOptions.ServiceCreate.Port,
 		Protocol:         ServiceOptions.ServiceCreate.Protocol,
-		ProxyProtocol:    &ServiceOptions.ServiceCreate.ProxyProtocol,
-		RequireApproval:  &requireApproval,
+		ProxyProtocol:    boolFlag(ServiceOptions.ServiceCreate.ProxyProtocol, ServiceOptions.ServiceCreate.NoProxyProtocol),
+		RequireApproval:  boolFlag(ServiceOptions.ServiceCreate.RequireApproval, ServiceOptions.ServiceCreate.NoRequireApproval),
 		Tags:             ServiceOptions.ServiceCreate.Tags,
 		Visibility:       ServiceOptions.ServiceCreate.Visibility,
 		AvailabilityZone: ServiceOptions.ServiceCreate.AvailabilityZone,
@@ -171,7 +169,8 @@ type ServiceSet struct {
 	Name              *string       `long:"name" description:"Service name"`
 	Port              []int32       `long:"port" description:"Port exposed by the service (repeat option to set multiple ports)"`
 	Protocol          *string       `long:"protocol" description:"Protocol type of the service" choice:"TCP" choice:"HTTP"`
-	ProxyProtocol     *bool         `long:"proxy-protocol" description:"Enable proxy protocol v2."`
+	ProxyProtocol     bool          `long:"proxy-protocol" description:"Enable proxy protocol v2."`
+	NoProxyProtocol   bool          `long:"no-proxy-protocol" description:"Disable proxy protocol v2."`
 	RequireApproval   bool          `long:"require-approval" description:"Require explicit project approval for the service owner."`
 	NoRequireApproval bool          `long:"no-require-approval" description:"Disable require approval for the service owner."`
 	Visibility        *string       `long:"visibility" description:"Set global visibility of the service. For private visibility, RBAC policies can extend the visibility to specific projects" choice:"private" choice:"public"`
@@ -204,31 +203,15 @@ func (*ServiceSet) Execute(_ []string) error {
 		tags = append(ServiceOptions.ServiceSet.Tags, resp.Payload.Tags...)
 	}
 
-	var enabled *bool
-	if ServiceOptions.ServiceSet.Enable {
-		t := true
-		enabled = &t
-	} else if ServiceOptions.ServiceSet.Disable {
-		t := false
-		enabled = &t
-	}
-	var requireApproval *bool
-	if ServiceOptions.ServiceSet.RequireApproval {
-		t := true
-		requireApproval = &t
-	} else if ServiceOptions.ServiceSet.NoRequireApproval {
-		t := false
-		requireApproval = &t
-	}
 	sv := models.ServiceUpdatable{
 		Description:     ServiceOptions.ServiceSet.Description,
-		Enabled:         enabled,
+		Enabled:         boolFlag(ServiceOptions.ServiceSet.Enable, ServiceOptions.ServiceSet.Disable),
 		IPAddresses:     ServiceOptions.ServiceSet.IPAddresses,
 		Name:            ServiceOptions.ServiceSet.Name,
 		Ports:           ServiceOptions.ServiceSet.Port,
 		Protocol:        ServiceOptions.ServiceSet.Protocol,
-		ProxyProtocol:   ServiceOptions.ServiceSet.ProxyProtocol,
-		RequireApproval: requireApproval,
+		ProxyProtocol:   boolFlag(ServiceOptions.ServiceSet.ProxyProtocol, ServiceOptions.ServiceSet.NoProxyProtocol),
+		RequireApproval: boolFlag(ServiceOptions.ServiceSet.RequireApproval, ServiceOptions.ServiceSet.NoRequireApproval),
 		Tags:            tags,
 		Visibility:      ServiceOptions.ServiceSet.Visibility,
 	}

--- a/internal/controller/service_test.go
+++ b/internal/controller/service_test.go
@@ -525,7 +525,7 @@ func (t *SuiteTest) TestPutServiceServiceIDRejectEndpointsHandler() {
 	// create service with require approval
 	svcReqApproval := testService
 	svcReqApproval.RequireApproval = conv.Pointer(true)
-	serviceId := t.createService(testService)
+	serviceId := t.createService(svcReqApproval)
 
 	// create endpoint
 	network := strfmt.UUID("d714f65e-bffd-494f-8219-8eb0a85d7a2d")

--- a/restapi/doc.go
+++ b/restapi/doc.go
@@ -145,7 +145,7 @@
 //	  https
 //	Host: localhost
 //	BasePath: /
-//	Version: 2.0.0
+//	Version: 2.2.1
 //	License: Apache 2.0 https://www.apache.org/licenses/LICENSE-2.0.html
 //	Contact: SAP SE / Converged Cloud https://sap.com
 //

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -56,7 +56,7 @@ func init() {
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "2.0.0",
+    "version": "2.2.1",
     "x-logo": {
       "altText": "Archer logo",
       "backgroundColor": "#FFFFFF",
@@ -2023,7 +2023,7 @@ func init() {
         "require_approval": {
           "description": "Require explicit project approval for the service owner.",
           "type": "boolean",
-          "default": true
+          "default": false
         },
         "status": {
           "$ref": "#/definitions/ServiceStatus"
@@ -2389,7 +2389,7 @@ func init() {
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "2.0.0",
+    "version": "2.2.1",
     "x-logo": {
       "altText": "Archer logo",
       "backgroundColor": "#FFFFFF",
@@ -4511,7 +4511,7 @@ func init() {
         "require_approval": {
           "description": "Require explicit project approval for the service owner.",
           "type": "boolean",
-          "default": true
+          "default": false
         },
         "status": {
           "$ref": "#/definitions/ServiceStatus"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4,7 +4,7 @@
 
 swagger: "2.0"
 info:
-  version: "2.0.0"
+  version: "2.2.1"
   title: "🏹 Archer"
   contact:
     name: SAP SE / Converged Cloud
@@ -1313,7 +1313,7 @@ definitions:
       require_approval:
         type: boolean
         description: Require explicit project approval for the service owner.
-        default: true
+        default: false
       visibility:
         type: string
         description: Set global visibility of the service. For `private` visibility, RBAC policies can extend the visibility to specific projects.


### PR DESCRIPTION
Boolean flags like --enable/--disable, --require-approval/--no-require-approval,
and --proxy-protocol/--no-proxy-protocol now return nil when neither flag is
specified, allowing the server's default values to apply instead of always
sending a value.

Added boolFlag() helper to consolidate the flag pair logic and added
--no-proxy-protocol flag to service create/set commands.
