### PR TITLE
feat: add Keystone-compatible version discovery response

### DIFF
--- a/client/version/get_responses.go
+++ b/client/version/get_responses.go
@@ -60,10 +60,10 @@ func NewGetOK() *GetOK {
 /*
 GetOK describes a response with status code 200, with default header values.
 
-Version
+Versions
 */
 type GetOK struct {
-	Payload *models.Version
+	Payload *models.Versions
 }
 
 // IsSuccess returns true when this get o k response has a 2xx status code
@@ -106,13 +106,13 @@ func (o *GetOK) String() string {
 	return fmt.Sprintf("[GET /][%d] getOK %s", 200, payload)
 }
 
-func (o *GetOK) GetPayload() *models.Version {
+func (o *GetOK) GetPayload() *models.Versions {
 	return o.Payload
 }
 
 func (o *GetOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.Version)
+	o.Payload = new(models.Versions)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && !stderrors.Is(err, io.EOF) {

--- a/client/version/version_client.go
+++ b/client/version/version_client.go
@@ -78,7 +78,12 @@ type ClientService interface {
 }
 
 /*
-Get shows details for archer API
+	Get shows keystone compatible version information for archer API
+
+	Returns version information in a Keystone-compatible format.
+
+The response follows the OpenStack version discovery format with
+versions array containing version objects with id, status, and links.
 */
 func (a *Client) Get(params *GetParams, opts ...ClientOption) (*GetOK, error) {
 	// NOTE: parameters are not validated before sending

--- a/internal/controller/version.go
+++ b/internal/controller/version.go
@@ -6,6 +6,7 @@ package controller
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/go-openapi/runtime/middleware"
 
@@ -13,6 +14,18 @@ import (
 	"github.com/sapcc/archer/models"
 	"github.com/sapcc/archer/restapi/operations/version"
 )
+
+// extractMicroversion extracts a valid Keystone version string from a full version string.
+// Keystone accepts: 'v1', 'v1.2', '1.2.3', 'v1.2.3', etc.
+// e.g., "v2.2.0-1-ge4ce034" -> "v2.2.0", "2.2.0" -> "2.2.0"
+func extractMicroversion(fullVersion string) string {
+	re := regexp.MustCompile(`^(v?\d+(?:\.\d+)*)`)
+	matches := re.FindStringSubmatch(fullVersion)
+	if len(matches) >= 2 {
+		return matches[1]
+	}
+	return "1.0.0"
+}
 
 func (c *Controller) GetVersionHandler(params version.GetParams) middleware.Responder {
 	var capabilities []string
@@ -36,13 +49,34 @@ func (c *Controller) GetVersionHandler(params version.GetParams) middleware.Resp
 		capabilities = append(capabilities, fmt.Sprintf("pagination_max=%d",
 			config.Global.ApiSettings.PaginationMaxLimit))
 	}
-	return version.NewGetOK().WithPayload(&models.Version{
+
+	baseURL := config.GetApiBaseUrl(params.HTTPRequest)
+	links := []*models.Link{
+		{Href: baseURL, Rel: "self"},
+	}
+
+	// Extract clean microversion for Keystone compatibility
+	microversion := extractMicroversion(config.Version)
+
+	return version.NewGetOK().WithPayload(&models.Versions{
+		// Keystone-compatible versions array
+		Versions: []*models.Version{
+			{
+				ID:           "v1",
+				Status:       "CURRENT",
+				Capabilities: capabilities,
+				Links: []*models.Link{
+					{Href: baseURL, Rel: "self"},
+					{Href: baseURL, Rel: "collection"},
+				},
+				Updated: config.BuildTime,
+				Version: microversion,
+			},
+		},
+		// Backward-compatible root-level fields
 		Capabilities: capabilities,
-		Links: []*models.Link{{
-			Href: config.GetApiBaseUrl(params.HTTPRequest),
-			Rel:  "self",
-		}},
-		Updated: config.BuildTime,
-		Version: config.Version,
+		Links:        links,
+		Updated:      config.BuildTime,
+		Version:      config.Version,
 	})
 }

--- a/internal/controller/version_test.go
+++ b/internal/controller/version_test.go
@@ -19,6 +19,8 @@ func (t *SuiteTest) TestVersion() {
 	res := t.c.GetVersionHandler(version.GetParams{HTTPRequest: &http.Request{}})
 	assert.IsType(t.T(), &version.GetOK{}, res)
 	payload := res.(*version.GetOK).Payload
+
+	// Test backward-compatible root-level fields (full version string)
 	assert.Equal(t.T(), config.Version, payload.Version)
 	assert.Contains(t.T(), payload.Capabilities, "pagination_max=1000")
 	assert.Contains(t.T(), payload.Capabilities, "pagination")
@@ -26,5 +28,49 @@ func (t *SuiteTest) TestVersion() {
 	assert.Contains(t.T(), payload.Capabilities, "cors")
 	assert.Contains(t.T(), payload.Capabilities, "keystone")
 	assert.Contains(t.T(), payload.Capabilities, "ratelimit=100.00")
+	assert.Len(t.T(), payload.Links, 1)
+	assert.Equal(t.T(), "self", payload.Links[0].Rel)
+
+	// Test Keystone-compatible versions array (clean microversion)
+	assert.Len(t.T(), payload.Versions, 1)
+	v := payload.Versions[0]
+	assert.Equal(t.T(), "v1", v.ID)
+	assert.Equal(t.T(), "CURRENT", v.Status)
+	// Keystone expects a clean major.minor version, not full git version
+	assert.Equal(t.T(), extractMicroversion(config.Version), v.Version)
+	assert.Contains(t.T(), v.Capabilities, "pagination_max=1000")
+	assert.Contains(t.T(), v.Capabilities, "pagination")
+	assert.Contains(t.T(), v.Capabilities, "sorting")
+	assert.Contains(t.T(), v.Capabilities, "cors")
+	assert.Contains(t.T(), v.Capabilities, "keystone")
+	assert.Contains(t.T(), v.Capabilities, "ratelimit=100.00")
+	assert.Len(t.T(), v.Links, 2)
+	assert.Equal(t.T(), "self", v.Links[0].Rel)
+	assert.Equal(t.T(), "collection", v.Links[1].Rel)
+
 	config.Global.ApiSettings.AuthStrategy = "none"
+}
+
+func (t *SuiteTest) TestExtractMicroversion() {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"v2.2.0-1-ge4ce034", "v2.2.0"},
+		{"v2.2.0", "v2.2.0"},
+		{"2.2.0", "2.2.0"},
+		{"v1.0.0", "v1.0.0"},
+		{"v10.20.30", "v10.20.30"},
+		{"v1", "v1"},
+		{"v1.2", "v1.2"},
+		{"1.2.3", "1.2.3"},
+		{"123", "123"},
+		{"invalid", "1.0.0"},
+		{"", "1.0.0"},
+	}
+
+	for _, tc := range tests {
+		result := extractMicroversion(tc.input)
+		assert.Equal(t.T(), tc.expected, result, "extractMicroversion(%q)", tc.input)
+	}
 }

--- a/models/versions.go
+++ b/models/versions.go
@@ -31,40 +31,39 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// Version Keystone-compatible version information
+// Versions Keystone-compatible versions response wrapper with backward-compatible root fields
 //
-// swagger:model Version
-type Version struct {
+// swagger:model Versions
+type Versions struct {
 
-	// capabilities
+	// Supported capabilities (deprecated, use versions[].capabilities)
 	// Example: ["pagination","sort"]
 	Capabilities []string `json:"capabilities"`
 
-	// Version identifier
-	// Example: v1
-	ID string `json:"id,omitempty"`
-
-	// links
+	// API links (deprecated, use versions[].links)
 	Links []*Link `json:"links"`
 
-	// Version status (CURRENT, SUPPORTED, DEPRECATED, EXPERIMENTAL)
-	// Example: CURRENT
-	Status string `json:"status,omitempty"`
-
-	// Last update of the running version
+	// Last update of the running version (deprecated, use versions[].updated)
 	// Example: 2018-09-30T00:00:00Z
 	Updated string `json:"updated,omitempty"`
 
-	// Version of Archer (max microversion)
+	// Version of Archer (deprecated, use versions[].version)
 	// Example: 1.3.0
 	Version string `json:"version,omitempty"`
+
+	// Keystone-compatible versions array
+	Versions []*Version `json:"versions"`
 }
 
-// Validate validates this version
-func (m *Version) Validate(formats strfmt.Registry) error {
+// Validate validates this versions
+func (m *Versions) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateLinks(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateVersions(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -74,7 +73,7 @@ func (m *Version) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *Version) validateLinks(formats strfmt.Registry) error {
+func (m *Versions) validateLinks(formats strfmt.Registry) error {
 	if swag.IsZero(m.Links) { // not required
 		return nil
 	}
@@ -104,11 +103,45 @@ func (m *Version) validateLinks(formats strfmt.Registry) error {
 	return nil
 }
 
-// ContextValidate validate this version based on the context it is used
-func (m *Version) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+func (m *Versions) validateVersions(formats strfmt.Registry) error {
+	if swag.IsZero(m.Versions) { // not required
+		return nil
+	}
+
+	for i := 0; i < len(m.Versions); i++ {
+		if swag.IsZero(m.Versions[i]) { // not required
+			continue
+		}
+
+		if m.Versions[i] != nil {
+			if err := m.Versions[i].Validate(formats); err != nil {
+				ve := new(errors.Validation)
+				if stderrors.As(err, &ve) {
+					return ve.ValidateName("versions" + "." + strconv.Itoa(i))
+				}
+				ce := new(errors.CompositeError)
+				if stderrors.As(err, &ce) {
+					return ce.ValidateName("versions" + "." + strconv.Itoa(i))
+				}
+
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this versions based on the context it is used
+func (m *Versions) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.contextValidateLinks(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateVersions(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -118,7 +151,7 @@ func (m *Version) ContextValidate(ctx context.Context, formats strfmt.Registry) 
 	return nil
 }
 
-func (m *Version) contextValidateLinks(ctx context.Context, formats strfmt.Registry) error {
+func (m *Versions) contextValidateLinks(ctx context.Context, formats strfmt.Registry) error {
 
 	for i := 0; i < len(m.Links); i++ {
 
@@ -147,8 +180,37 @@ func (m *Version) contextValidateLinks(ctx context.Context, formats strfmt.Regis
 	return nil
 }
 
+func (m *Versions) contextValidateVersions(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Versions); i++ {
+
+		if m.Versions[i] != nil {
+
+			if swag.IsZero(m.Versions[i]) { // not required
+				return nil
+			}
+
+			if err := m.Versions[i].ContextValidate(ctx, formats); err != nil {
+				ve := new(errors.Validation)
+				if stderrors.As(err, &ve) {
+					return ve.ValidateName("versions" + "." + strconv.Itoa(i))
+				}
+				ce := new(errors.CompositeError)
+				if stderrors.As(err, &ce) {
+					return ce.ValidateName("versions" + "." + strconv.Itoa(i))
+				}
+
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
 // MarshalBinary interface implementation
-func (m *Version) MarshalBinary() ([]byte, error) {
+func (m *Versions) MarshalBinary() ([]byte, error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -156,8 +218,8 @@ func (m *Version) MarshalBinary() ([]byte, error) {
 }
 
 // UnmarshalBinary interface implementation
-func (m *Version) UnmarshalBinary(b []byte) error {
-	var res Version
+func (m *Versions) UnmarshalBinary(b []byte) error {
+	var res Versions
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -67,15 +67,16 @@ func init() {
     "/": {
       "get": {
         "security": [],
+        "description": "Returns version information in a Keystone-compatible format.\nThe response follows the OpenStack version discovery format with\nversions array containing version objects with id, status, and links.\n",
         "tags": [
           "Version"
         ],
-        "summary": "Shows details for Archer API",
+        "summary": "Shows Keystone-compatible version information for Archer API",
         "responses": {
           "200": {
-            "description": "Version",
+            "description": "Versions",
             "schema": {
-              "$ref": "#/definitions/Version"
+              "$ref": "#/definitions/Versions"
             }
           }
         }
@@ -2160,6 +2161,7 @@ func init() {
       "example": "2023-03-31T18:37:54.581099Z"
     },
     "Version": {
+      "description": "Keystone-compatible version information",
       "type": "object",
       "properties": {
         "capabilities": {
@@ -2172,11 +2174,21 @@ func init() {
             "sort"
           ]
         },
+        "id": {
+          "description": "Version identifier",
+          "type": "string",
+          "example": "v1"
+        },
         "links": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Link"
           }
+        },
+        "status": {
+          "description": "Version status (CURRENT, SUPPORTED, DEPRECATED, EXPERIMENTAL)",
+          "type": "string",
+          "example": "CURRENT"
         },
         "updated": {
           "description": "Last update of the running version",
@@ -2184,9 +2196,50 @@ func init() {
           "example": "2018-09-30T00:00:00Z"
         },
         "version": {
-          "description": "Version of Archer",
+          "description": "Version of Archer (max microversion)",
           "type": "string",
           "example": "1.3.0"
+        }
+      }
+    },
+    "Versions": {
+      "description": "Keystone-compatible versions response wrapper with backward-compatible root fields",
+      "type": "object",
+      "properties": {
+        "capabilities": {
+          "description": "Supported capabilities (deprecated, use versions[].capabilities)",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "example": [
+            "pagination",
+            "sort"
+          ]
+        },
+        "links": {
+          "description": "API links (deprecated, use versions[].links)",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Link"
+          }
+        },
+        "updated": {
+          "description": "Last update of the running version (deprecated, use versions[].updated)",
+          "type": "string",
+          "example": "2018-09-30T00:00:00Z"
+        },
+        "version": {
+          "description": "Version of Archer (deprecated, use versions[].version)",
+          "type": "string",
+          "example": "1.3.0"
+        },
+        "versions": {
+          "description": "Keystone-compatible versions array",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Version"
+          }
         }
       }
     }
@@ -2347,15 +2400,16 @@ func init() {
     "/": {
       "get": {
         "security": [],
+        "description": "Returns version information in a Keystone-compatible format.\nThe response follows the OpenStack version discovery format with\nversions array containing version objects with id, status, and links.\n",
         "tags": [
           "Version"
         ],
-        "summary": "Shows details for Archer API",
+        "summary": "Shows Keystone-compatible version information for Archer API",
         "responses": {
           "200": {
-            "description": "Version",
+            "description": "Versions",
             "schema": {
-              "$ref": "#/definitions/Version"
+              "$ref": "#/definitions/Versions"
             }
           }
         }
@@ -4596,6 +4650,7 @@ func init() {
       "example": "2023-03-31T18:37:54.581099Z"
     },
     "Version": {
+      "description": "Keystone-compatible version information",
       "type": "object",
       "properties": {
         "capabilities": {
@@ -4608,11 +4663,21 @@ func init() {
             "sort"
           ]
         },
+        "id": {
+          "description": "Version identifier",
+          "type": "string",
+          "example": "v1"
+        },
         "links": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Link"
           }
+        },
+        "status": {
+          "description": "Version status (CURRENT, SUPPORTED, DEPRECATED, EXPERIMENTAL)",
+          "type": "string",
+          "example": "CURRENT"
         },
         "updated": {
           "description": "Last update of the running version",
@@ -4620,9 +4685,50 @@ func init() {
           "example": "2018-09-30T00:00:00Z"
         },
         "version": {
-          "description": "Version of Archer",
+          "description": "Version of Archer (max microversion)",
           "type": "string",
           "example": "1.3.0"
+        }
+      }
+    },
+    "Versions": {
+      "description": "Keystone-compatible versions response wrapper with backward-compatible root fields",
+      "type": "object",
+      "properties": {
+        "capabilities": {
+          "description": "Supported capabilities (deprecated, use versions[].capabilities)",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "example": [
+            "pagination",
+            "sort"
+          ]
+        },
+        "links": {
+          "description": "API links (deprecated, use versions[].links)",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Link"
+          }
+        },
+        "updated": {
+          "description": "Last update of the running version (deprecated, use versions[].updated)",
+          "type": "string",
+          "example": "2018-09-30T00:00:00Z"
+        },
+        "version": {
+          "description": "Version of Archer (deprecated, use versions[].version)",
+          "type": "string",
+          "example": "1.3.0"
+        },
+        "versions": {
+          "description": "Keystone-compatible versions array",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Version"
+          }
         }
       }
     }

--- a/restapi/operations/version/get.go
+++ b/restapi/operations/version/get.go
@@ -48,7 +48,11 @@ func NewGet(ctx *middleware.Context, handler GetHandler) *Get {
 /*
 	Get swagger:route GET / Version get
 
-Shows details for Archer API
+# Shows Keystone-compatible version information for Archer API
+
+Returns version information in a Keystone-compatible format.
+The response follows the OpenStack version discovery format with
+versions array containing version objects with id, status, and links.
 */
 type Get struct {
 	Context *middleware.Context

--- a/restapi/operations/version/get_responses.go
+++ b/restapi/operations/version/get_responses.go
@@ -33,7 +33,7 @@ import (
 const GetOKCode int = 200
 
 /*
-GetOK Version
+GetOK Versions
 
 swagger:response getOK
 */
@@ -42,7 +42,7 @@ type GetOK struct {
 	/*
 	  In: Body
 	*/
-	Payload *models.Version `json:"body,omitempty"`
+	Payload *models.Versions `json:"body,omitempty"`
 }
 
 // NewGetOK creates GetOK with default headers values
@@ -52,13 +52,13 @@ func NewGetOK() *GetOK {
 }
 
 // WithPayload adds the payload to the get o k response
-func (o *GetOK) WithPayload(payload *models.Version) *GetOK {
+func (o *GetOK) WithPayload(payload *models.Versions) *GetOK {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the get o k response
-func (o *GetOK) SetPayload(payload *models.Version) {
+func (o *GetOK) SetPayload(payload *models.Versions) {
 	o.Payload = payload
 }
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -193,12 +193,16 @@ paths:
       security: []
       tags:
         - Version
-      summary: Shows details for Archer API
+      summary: Shows Keystone-compatible version information for Archer API
+      description: |
+        Returns version information in a Keystone-compatible format.
+        The response follows the OpenStack version discovery format with
+        versions array containing version objects with id, status, and links.
       responses:
         200:
-          description: Version
+          description: Versions
           schema:
-            $ref: "#/definitions/Version"
+            $ref: "#/definitions/Versions"
   /service:
     get:
       tags:
@@ -1714,14 +1718,23 @@ definitions:
         x-omitempty: false
   Version:
     type: object
+    description: Keystone-compatible version information
     properties:
+      id:
+        type: string
+        description: Version identifier
+        example: v1
+      status:
+        type: string
+        description: Version status (CURRENT, SUPPORTED, DEPRECATED, EXPERIMENTAL)
+        example: CURRENT
       updated:
         type: string
         description: Last update of the running version
         example: "2018-09-30T00:00:00Z"
       version:
         type: string
-        description: Version of Archer
+        description: Version of Archer (max microversion)
         example: 1.3.0
       links:
         type: array
@@ -1729,6 +1742,35 @@ definitions:
           $ref: "#/definitions/Link"
       capabilities:
         type: array
+        example: ["pagination", "sort"]
+        items:
+          type: string
+  Versions:
+    type: object
+    description: Keystone-compatible versions response wrapper with backward-compatible root fields
+    properties:
+      versions:
+        type: array
+        description: Keystone-compatible versions array
+        items:
+          $ref: "#/definitions/Version"
+      # Backward-compatible root-level fields (deprecated, use versions array instead)
+      updated:
+        type: string
+        description: Last update of the running version (deprecated, use versions[].updated)
+        example: "2018-09-30T00:00:00Z"
+      version:
+        type: string
+        description: Version of Archer (deprecated, use versions[].version)
+        example: 1.3.0
+      links:
+        type: array
+        description: API links (deprecated, use versions[].links)
+        items:
+          $ref: "#/definitions/Link"
+      capabilities:
+        type: array
+        description: Supported capabilities (deprecated, use versions[].capabilities)
         example: ["pagination", "sort"]
         items:
           type: string


### PR DESCRIPTION
The version endpoint now returns a Keystone-compatible format with a `versions` array containing `id`, `status`, and `version` fields. This allows `openstack versions show` to work with Archer.

Backward compatibility is maintained by keeping the original root-level fields (version, updated, capabilities, links).