### PR TITLE
feat: add automated release drafting workflows

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright 2025 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Create Release Tag
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  create-tag:
+    name: Create release tag
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/v')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from branch name
+        id: version
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          VERSION="${BRANCH#release/}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Create annotated tag
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git tag -a "${VERSION}" -m "Release ${VERSION}"
+          git push origin "${VERSION}"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: Copyright 2025 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Draft Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  check-unreleased:
+    name: Check for unreleased changes
+    runs-on: ubuntu-latest
+    outputs:
+      has_unreleased: ${{ steps.check.outputs.has_unreleased }}
+      next_version: ${{ steps.version.outputs.next_version }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Read unreleased changelog
+        id: changelog
+        uses: mindsers/changelog-reader-action@v2
+        with:
+          version: Unreleased
+          path: ./CHANGELOG.md
+
+      - name: Check if unreleased section has content
+        id: check
+        run: |
+          if [ -n "${{ steps.changelog.outputs.changes }}" ]; then
+            echo "has_unreleased=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_unreleased=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get latest version and calculate next
+        id: version
+        if: steps.check.outputs.has_unreleased == 'true'
+        run: |
+          # Get latest version from changelog
+          LATEST=$(grep -m1 '## \[[0-9]' CHANGELOG.md | sed 's/.*\[\([0-9.]*\)\].*/\1/')
+          echo "Latest version: $LATEST"
+
+          # Calculate next patch version
+          IFS='.' read -r major minor patch <<< "$LATEST"
+          NEXT="${major}.${minor}.$((patch + 1))"
+          echo "Next version: $NEXT"
+          echo "next_version=$NEXT" >> $GITHUB_OUTPUT
+
+  draft-release:
+    name: Draft release PR
+    needs: check-unreleased
+    if: needs.check-unreleased.outputs.has_unreleased == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize git config
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+
+      - name: Check for existing release branch
+        id: check_branch
+        run: |
+          if git ls-remote --exit-code --heads origin release/v${{ needs.check-unreleased.outputs.next_version }}; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create or update release branch
+        run: |
+          VERSION="${{ needs.check-unreleased.outputs.next_version }}"
+          BRANCH="release/v${VERSION}"
+
+          if [ "${{ steps.check_branch.outputs.exists }}" == "true" ]; then
+            # Update existing branch by rebasing on main
+            git fetch origin ${BRANCH}
+            git checkout ${BRANCH}
+            git reset --hard origin/main
+          else
+            # Create new branch
+            git checkout -b ${BRANCH}
+          fi
+
+      - name: Update changelog
+        uses: thomaseizinger/keep-a-changelog-new-release@v3
+        with:
+          tag: v${{ needs.check-unreleased.outputs.next_version }}
+
+      - name: Update swagger.yaml version
+        run: |
+          VERSION="${{ needs.check-unreleased.outputs.next_version }}"
+          sed -i "s/^  version: .*/  version: \"${VERSION}\"/" swagger.yaml
+
+      - name: Commit changes
+        id: commit
+        run: |
+          VERSION="${{ needs.check-unreleased.outputs.next_version }}"
+          git add CHANGELOG.md swagger.yaml
+          git commit --message "chore: release v${VERSION}"
+          echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Push branch
+        run: |
+          VERSION="${{ needs.check-unreleased.outputs.next_version }}"
+          git push --force origin release/v${VERSION}
+
+      - name: Create or update pull request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          branch: release/v${{ needs.check-unreleased.outputs.next_version }}
+          base: main
+          title: "chore: release v${{ needs.check-unreleased.outputs.next_version }}"
+          body: |
+            ## Release v${{ needs.check-unreleased.outputs.next_version }}
+
+            This PR was automatically created/updated because unreleased changes were detected in the changelog.
+
+            **Changes in this release:**
+            - Updated CHANGELOG.md with release date
+            - Updated swagger.yaml version to ${{ needs.check-unreleased.outputs.next_version }}
+
+            **Commit:** ${{ steps.commit.outputs.commit }}
+
+            ---
+
+            Merging this PR will automatically create an annotated tag `v${{ needs.check-unreleased.outputs.next_version }}` on main.
+          labels: release


### PR DESCRIPTION
- draft-release.yml: detects unreleased changelog entries on push to main, creates/updates a release PR with version bump in CHANGELOG.md and swagger.yaml
- create-release-tag.yml: creates annotated tag when release PR is merged