### PR TITLE
fix(agent): tolerate missing ports for endpoints pending deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- F5 agent: tolerate missing Neutron ports when endpoints are pending deletion/rejection
+- Agent: fix DB notification thread reconnection - properly re-acquire connection when lost
+- Agent: clarify log field names (`job_id`, `endpoint_ids`) for better debugging
+
 ## [2.2.0] - 2026-04-16
 
 ### Added

--- a/internal/agent/common.go
+++ b/internal/agent/common.go
@@ -6,7 +6,6 @@ package agent
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"time"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/sapcc/archer/internal/config"
@@ -82,7 +82,7 @@ func NewScheduler() gocron.Scheduler {
 					log.Debugf("Job FINISHED: name=%s, id=%s", jobName, jobID)
 				}),
 				gocron.AfterJobRunsWithError(func(jobID uuid.UUID, jobName string, err error) {
-					log.Errorf("Job FAILED: name=%s, id=%s, error=%v", jobName, jobID, err)
+					log.Errorf("Job FAILED: name=%s, job_id=%s, error=%v", jobName, jobID, err)
 				}),
 			),
 		),
@@ -94,40 +94,68 @@ func NewScheduler() gocron.Scheduler {
 }
 
 func DBNotificationThread(ctx context.Context, w Worker) {
-	// Acquire one Connection for listen events
-	conn, err := w.GetPool().Acquire(ctx)
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-
-	sql := "LISTEN service; LISTEN endpoint;"
-	if _, err := conn.Exec(ctx, sql); err != nil {
-		log.Fatal(err.Error())
-	}
-
 	const reconnectionDelay = time.Minute / 2
-	log.Infof("DBNotificationThread: Listening to service and endpoint notifications, reconnection delay %v",
-		reconnectionDelay)
 
 	for {
-		var id strfmt.UUID
+		// Check if context is canceled before acquiring connection
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		// Acquire a connection for listen events
+		conn, err := w.GetPool().Acquire(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return // Context cancelled, graceful shutdown
+			}
+			log.WithError(err).Error("DBNotificationThread: Failed to acquire connection")
+			time.Sleep(reconnectionDelay)
+			continue
+		}
+
+		sql := "LISTEN service; LISTEN endpoint;"
+		if _, err = conn.Exec(ctx, sql); err != nil {
+			conn.Release()
+			if ctx.Err() != nil {
+				return // Context cancelled, graceful shutdown
+			}
+			log.WithError(err).Error("DBNotificationThread: Failed to setup LISTEN")
+			time.Sleep(reconnectionDelay)
+			continue
+		}
+
+		log.Infof("DBNotificationThread: Listening to service and endpoint notifications, reconnection delay %v",
+			reconnectionDelay)
+
+		// Process notifications until connection error
+		if err = processNotifications(ctx, conn, w); err != nil {
+			conn.Release()
+			if ctx.Err() != nil {
+				return // Context cancelled, graceful shutdown
+			}
+			log.WithError(err).Warn("DBNotificationThread: Connection lost, reconnecting...")
+			time.Sleep(reconnectionDelay)
+			continue
+		}
+
+		conn.Release()
+		return // Context canceled
+	}
+}
+
+func processNotifications(ctx context.Context, conn *pgxpool.Conn, w Worker) error {
+	for {
 		notification, err := conn.Conn().WaitForNotification(ctx)
 		if err != nil {
-			if !pgconn.Timeout(err) {
-				if connectionError, ok := errors.AsType[*pgconn.ConnectError](err); ok {
-					log.Errorf("DBNotificationThread: Connection error: %v", connectionError.Error())
-				} else {
-					log.Warnf("DBNotificationThread: Wait for Notification timeout: %v", err)
-				}
-
-				select {
-				case <-ctx.Done():
-					return
-				case <-time.After(reconnectionDelay):
-					// Wait a while to avoid busy-looping while the database is unreachable.
-				}
+			if ctx.Err() != nil {
+				return nil // Context cancelled, graceful shutdown
 			}
-			continue
+			if pgconn.Timeout(err) {
+				continue // Timeout is normal, just retry
+			}
+			return err // Connection error, need to reconnect
 		}
 
 		log.Debugf("Received notification, channel=%s, payload=%s", notification.Channel, notification.Payload)
@@ -140,6 +168,8 @@ func DBNotificationThread(ctx context.Context, w Worker) {
 		if s[0] != config.Global.Default.Host {
 			continue
 		}
+
+		var id strfmt.UUID
 		if len(s) > 1 {
 			id = strfmt.UUID(s[1])
 		}
@@ -167,7 +197,7 @@ func DBNotificationThread(ctx context.Context, w Worker) {
 				gocron.WithTags(id.String()),
 				gocron.WithContext(ctx),
 			); nil != err {
-				log.WithError(err).WithField("id", id).Error("failed enqueueing ProcessEndpoint job")
+				log.WithError(err).WithField("endpoint_id", id).Error("failed enqueueing ProcessEndpoint job")
 			}
 		}
 	}

--- a/internal/agent/f5/endpoints.go
+++ b/internal/agent/f5/endpoints.go
@@ -46,7 +46,7 @@ func (a *Agent) populateEndpointPorts(endpoints []*as3.ExtendedEndpoint) error {
 	}
 
 	if len(endpointPorts) == 0 {
-		return fmt.Errorf("no neutron ports found for endpoint(s) %s", opts.IDs)
+		return fmt.Errorf("%w for port_ids=%s", aErrors.ErrNoPortsFound, opts.IDs)
 	}
 	for _, port := range endpointPorts {
 		for _, endpoint := range endpoints {
@@ -97,6 +97,16 @@ func checkAllPendingDelete(endpoints []*as3.ExtendedEndpoint, subnetID string) b
 		}
 	}
 
+	return true
+}
+
+// allEndpointsPendingDeletion returns true if all endpoints are in PENDING_DELETE or PENDING_REJECTED status
+func allEndpointsPendingDeletion(endpoints []*as3.ExtendedEndpoint) bool {
+	for _, endpoint := range endpoints {
+		if endpoint.Status != models.EndpointStatusPENDINGDELETE && endpoint.Status != models.EndpointStatusPENDINGREJECTED {
+			return false
+		}
+	}
 	return true
 }
 
@@ -199,10 +209,10 @@ func (a *Agent) ProcessEndpoint(ctx context.Context, endpointID strfmt.UUID) err
 	}
 	g.Go(func() error {
 		err = a.populateEndpointPorts(endpoints)
-		if err != nil && cleanupL2 {
+		if errors.Is(err, aErrors.ErrNoPortsFound) && allEndpointsPendingDeletion(endpoints) {
 			// ignore missing ports if all endpoints are about to be deleted, print warning instead
 			log.WithError(err).
-				Warning("Ignoring missing ports for endpoint(s) since endpoints are about to be deleted.")
+				Warning("Ignoring missing ports since all endpoints are pending deletion/rejection")
 			return nil
 		}
 		return err

--- a/internal/agent/f5/endpoints_test.go
+++ b/internal/agent/f5/endpoints_test.go
@@ -112,6 +112,12 @@ const GetPortListResponseFixture = `
 }
 `
 
+const EmptyPortListResponseFixture = `
+{
+	"ports": []
+}
+`
+
 var PostBigIPFixture = &as3.AS3{
 	Persist: false,
 	Class:   "AS3",
@@ -266,6 +272,9 @@ func TestAgent_DeleteEndpointWithDeletedNetwork(t *testing.T) {
 	config.Global.Agent.PhysicalNetwork = "physnet1"
 	fixture.SetupHandler(t, fakeServer, "/v2.0/networks/"+network.String(), "GET",
 		"", GetNetworkResponseFixture, http.StatusNotFound)
+	// Ports are deleted along with network - return empty list
+	fixture.SetupHandler(t, fakeServer, "/v2.0/ports", "GET",
+		"", EmptyPortListResponseFixture, http.StatusOK)
 
 	ctx := context.Background()
 	dbMock, err := pgxmock.NewPool(pgxmock.QueryMatcherOption(pgxmock.QueryMatcherEqual))

--- a/internal/agent/logger.go
+++ b/internal/agent/logger.go
@@ -46,10 +46,10 @@ func (d *DebugMonitor) RecordJobTiming(startTime, endTime time.Time, id uuid.UUI
 
 func (d *DebugMonitor) RecordJobTimingWithStatus(startTime, endTime time.Time, id uuid.UUID, name string, tags []string, status gocron.JobStatus, err error) {
 	logWithFields := log.WithFields(log.Fields{
-		"id":       id,
-		"tags":     tags,
-		"status":   status,
-		"duration": endTime.Sub(startTime),
+		"job_id":       id,
+		"endpoint_ids": tags,
+		"status":       status,
+		"duration":     endTime.Sub(startTime),
 	})
 
 	if err != nil {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -20,4 +20,5 @@ var (
 	ErrNoPhysNetFound   = errors.New("no physical network found")
 	ErrNoSubnetFound    = errors.New("no subnet(s) found")
 	ErrNoIPsAvailable   = errors.New("no IPs left")
+	ErrNoPortsFound     = errors.New("no neutron ports found")
 )


### PR DESCRIPTION
## Summary

- F5 agent: tolerate missing Neutron ports when endpoints are pending deletion/rejection
- Agent: fix DB notification thread reconnection - properly re-acquire connection when lost  
- Agent: clarify log field names (`job_id`, `endpoint_ids`) for better debugging

## Details

**Endpoint deletion tolerance:** When an endpoint is in `PENDING_DELETE` or `PENDING_REJECTED` status and its associated Neutron port has already been deleted, the endpoint deletion would get stuck with repeated errors. Now uses typed `ErrNoPortsFound` error to handle this case gracefully.

**DB notification reconnection:** Previously, when the database connection was closed (idle timeout, network issues), the notification thread would log repeated "conn closed" warnings while continuing to use the same broken connection. Now properly re-acquires a new connection.

**Log clarity:** Renamed ambiguous log fields (`id` → `job_id`, `tags` → `endpoint_ids`) to make debugging easier.
