### PR TITLE
fix(server): notify agent when endpoints are accepted or rejected

### DIFF
--- a/internal/controller/service.go
+++ b/internal/controller/service.go
@@ -607,6 +607,19 @@ func commonEndpointsActionHandler(pool db.PgxIface, body any, _ any) ([]*models.
 		return nil, dbscan.ErrNotFound
 	}
 
+	// Get host for notification
+	sql, args = db.Select("host").
+		From("service").
+		Where("id = ?", serviceId).
+		MustSql()
+	var host string
+	if err = pgxscan.Get(httpRequest.Context(), pool, &host, sql, args...); err == nil {
+		// Notify agent for each updated endpoint
+		for _, ec := range endpointConsumers {
+			db.NotifyEndpoint(pool, host, ec.ID)
+		}
+	}
+
 	return endpointConsumers, nil
 }
 


### PR DESCRIPTION
## Summary

When accepting or rejecting endpoints via the service API (`PUT /service/{id}/accept_endpoints` or `PUT /service/{id}/reject_endpoints`), the agent was not notified, causing endpoints to remain in `PENDING_CREATE` or `PENDING_REJECTED` status until the next scheduled sync.

## Changes

- Call `db.NotifyEndpoint` for each updated endpoint in `commonEndpointsActionHandler`

## Test plan

- [x] Accept an endpoint via API and verify it transitions to `AVAILABLE` immediately
- [x] Reject an endpoint via API and verify it transitions to `REJECTED` immediately