### PR TITLE
fix: endpoint port handling and notification improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- F5 agent: optimize `populateEndpointPorts` with O(n+m) map-based lookups and handle missing ports gracefully
+- F5 agent: retain Neutron ports on rejection to enable re-acceptance without port recreation
+- NI agent: `DisableInjection` no longer fetches port from Neutron, allowing cleanup even if port was manually deleted
+- Server: log error when notification host lookup fails in accept/reject handler
+
 ## [2.3.1] - 2026-04-22
 
 ### Fixed

--- a/internal/agent/f5/endpoints.go
+++ b/internal/agent/f5/endpoints.go
@@ -15,7 +15,6 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/ports"
-	"github.com/gophercloud/gophercloud/v2/pagination"
 	"github.com/jackc/pgx/v5"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -29,13 +28,18 @@ import (
 )
 
 func (a *Agent) populateEndpointPorts(endpoints []*as3.ExtendedEndpoint) error {
-	// Fetch ports from neutron
-	var opts neutron.PortListOpts
+	// Build map of port ID -> endpoints for O(1) lookup
+	endpointsByPort := make(map[string][]*as3.ExtendedEndpoint, len(endpoints))
+	opts := neutron.PortListOpts{
+		IDs: make([]string, 0, len(endpoints)),
+	}
 	for _, endpoint := range endpoints {
-		opts.IDs = append(opts.IDs, endpoint.Target.Port.String())
+		portID := endpoint.Target.Port.String()
+		opts.IDs = append(opts.IDs, portID)
+		endpointsByPort[portID] = append(endpointsByPort[portID], endpoint)
 	}
 
-	var pages pagination.Page
+	// Fetch ports from neutron
 	pages, err := ports.List(a.neutron.ServiceClient, opts).AllPages(context.Background())
 	if err != nil {
 		return err
@@ -45,16 +49,27 @@ func (a *Agent) populateEndpointPorts(endpoints []*as3.ExtendedEndpoint) error {
 		return err
 	}
 
-	if len(endpointPorts) == 0 {
-		return fmt.Errorf("%w for port_ids=%s", aErrors.ErrNoPortsFound, opts.IDs)
-	}
+	// Populate endpoints using map lookup
 	for _, port := range endpointPorts {
-		for _, endpoint := range endpoints {
-			if endpoint.Target.Port.String() == port.ID {
-				n := port
-				endpoint.Port = &n
+		p := port
+		for _, endpoint := range endpointsByPort[port.ID] {
+			endpoint.Port = &p
+		}
+		delete(endpointsByPort, port.ID)
+	}
+
+	// Check remaining entries - only fail if missing ports belong to non-deleting endpoints
+	var missingPorts []string
+	for portID, eps := range endpointsByPort {
+		for _, ep := range eps {
+			if ep.Status != models.EndpointStatusPENDINGDELETE && ep.Status != models.EndpointStatusPENDINGREJECTED {
+				missingPorts = append(missingPorts, portID)
+				break
 			}
 		}
+	}
+	if len(missingPorts) > 0 {
+		return fmt.Errorf("%w for port_ids=%s", aErrors.ErrNoPortsFound, missingPorts)
 	}
 
 	return nil
@@ -97,16 +112,6 @@ func checkAllPendingDelete(endpoints []*as3.ExtendedEndpoint, subnetID string) b
 		}
 	}
 
-	return true
-}
-
-// allEndpointsPendingDeletion returns true if all endpoints are in PENDING_DELETE or PENDING_REJECTED status
-func allEndpointsPendingDeletion(endpoints []*as3.ExtendedEndpoint) bool {
-	for _, endpoint := range endpoints {
-		if endpoint.Status != models.EndpointStatusPENDINGDELETE && endpoint.Status != models.EndpointStatusPENDINGREJECTED {
-			return false
-		}
-	}
 	return true
 }
 
@@ -208,14 +213,7 @@ func (a *Agent) ProcessEndpoint(ctx context.Context, endpointID strfmt.UUID) err
 		})
 	}
 	g.Go(func() error {
-		err = a.populateEndpointPorts(endpoints)
-		if errors.Is(err, aErrors.ErrNoPortsFound) && allEndpointsPendingDeletion(endpoints) {
-			// ignore missing ports if all endpoints are about to be deleted, print warning instead
-			log.WithError(err).
-				Warning("Ignoring missing ports since all endpoints are pending deletion/rejection")
-			return nil
-		}
-		return err
+		return a.populateEndpointPorts(endpoints)
 	})
 
 	// Wait for populating endpoints struct

--- a/internal/agent/f5/endpoints.go
+++ b/internal/agent/f5/endpoints.go
@@ -217,7 +217,7 @@ func (a *Agent) ProcessEndpoint(ctx context.Context, endpointID strfmt.UUID) err
 	})
 
 	// Wait for populating endpoints struct
-	if err := g.Wait(); err != nil {
+	if err = g.Wait(); err != nil {
 		return err
 	}
 
@@ -292,15 +292,8 @@ func (a *Agent) ProcessEndpoint(ctx context.Context, endpointID strfmt.UUID) err
 	for _, endpoint := range endpoints {
 		switch endpoint.Status {
 		case models.EndpointStatusPENDINGREJECTED:
-			// Delete endpoint neutron port, if it exists and is owned by the agent
-			if endpoint.Target.Port != nil && endpoint.Owned {
-				if err = a.neutron.DeletePort(endpoint.Target.Port.String()); err != nil {
-					if !gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
-						return err
-					}
-				}
-			}
-
+			// Don't delete the port here - keep it so the endpoint can be re-accepted later.
+			// The port will be deleted when the endpoint is actually deleted.
 			log.Infof("ProcessEndpoint: Rejecting endpoint %s", endpoint.ID)
 			sql, args = db.
 				Update("endpoint").
@@ -310,8 +303,8 @@ func (a *Agent) ProcessEndpoint(ctx context.Context, endpointID strfmt.UUID) err
 				MustSql()
 		case models.EndpointStatusPENDINGDELETE:
 			// Delete endpoint neutron port, if it exists and is owned by the agent
-			if endpoint.Target.Port != nil && endpoint.Owned {
-				if err = a.neutron.DeletePort(endpoint.Target.Port.String()); err != nil {
+			if endpoint.Port != nil && endpoint.Owned {
+				if err = a.neutron.DeletePort(endpoint.Port.ID); err != nil {
 					if !gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
 						return err
 					}
@@ -325,10 +318,10 @@ func (a *Agent) ProcessEndpoint(ctx context.Context, endpointID strfmt.UUID) err
 				MustSql()
 		case models.EndpointStatusPENDINGUPDATE:
 			// Update port binding to this host (needed after service migration)
-			if endpoint.Target.Port != nil {
+			if endpoint.Port != nil {
 				log.Infof("ProcessEndpoint: Updating port binding for endpoint %s to host %s",
 					endpoint.ID, config.Global.Default.Host)
-				if err = a.neutron.UpdatePortBinding(ctx, endpoint.Target.Port.String(), config.Global.Default.Host); err != nil {
+				if err = a.neutron.UpdatePortBinding(ctx, endpoint.Port.ID, config.Global.Default.Host); err != nil {
 					return err
 				}
 			}

--- a/internal/agent/ni/openstack.go
+++ b/internal/agent/ni/openstack.go
@@ -94,17 +94,16 @@ func (a *Agent) EnableInjection(si *models.ServiceInjection) error {
 }
 
 func (a *Agent) DisableInjection(si *models.ServiceInjection) error {
-	injectorPort, err := ports.Get(context.Background(), a.neutron, si.PortId.String()).Extract()
-	if err != nil {
-		return fmt.Errorf("failed to get port %s: %w", si.PortId, err)
-	}
+	// Use the Network field directly instead of fetching from Neutron.
+	// This allows cleanup to proceed even if the port was manually deleted.
+	networkID := si.Network.String()
 
 	// Only stop haproxy - don't delete the namespace.
 	// Other endpoints may still be using this network's namespace.
 	// The namespace will be cleaned up when the Neutron port is deleted,
 	// or reused if another endpoint is created for this network.
-	if a.haproxy.IsRunning(injectorPort.NetworkID) {
-		if err := a.haproxy.RemoveInstance(injectorPort.NetworkID); err != nil {
+	if a.haproxy.IsRunning(networkID) {
+		if err := a.haproxy.RemoveInstance(networkID); err != nil {
 			return fmt.Errorf("failed to remove haproxy instance: %w", err)
 		}
 	}

--- a/internal/agent/ni/openstack_test.go
+++ b/internal/agent/ni/openstack_test.go
@@ -169,60 +169,35 @@ func TestAgent_EnableInjection_Success(t *testing.T) {
 }
 
 func TestAgent_DisableInjection_PortNotFound(t *testing.T) {
-	portID := "550e8400-e29b-41d4-a716-446655440000"
-
-	// Setup mock HTTP handler to return 404 for port get
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "GET" && (r.URL.Path == "/ports/"+portID || r.URL.Path == "/v2.0/ports/"+portID) {
-			w.WriteHeader(http.StatusNotFound)
-			_, _ = fmt.Fprintf(w, `{"NeutronError": {"type": "PortNotFound", "message": "Port not found", "detail": ""}}`)
-			return
-		}
-		w.WriteHeader(http.StatusInternalServerError)
-	}
-
-	server, client := setupTestServer(http.HandlerFunc(handler))
-	defer server.Close()
-
-	agent := &Agent{
-		neutron: client,
-	}
-
+	// DisableInjection no longer fetches the port from Neutron,
+	// so it should succeed even if the port was deleted.
+	// This allows rejected/deleted endpoints to be processed even
+	// when the underlying Neutron port was manually removed.
 	networkID := strfmt.UUID("660e8400-e29b-41d4-a716-446655440000")
 
+	agent := &Agent{
+		haproxy: haproxy.NewFakeHaproxy(),
+	}
+
 	si := &models.ServiceInjection{
-		PortId:          strfmt.UUID(portID),
+		PortId:          strfmt.UUID("550e8400-e29b-41d4-a716-446655440000"),
 		Network:         networkID,
 		ServicePorts:    []int{80},
 		ServiceProtocol: "tcp",
 	}
 
 	err := agent.DisableInjection(si)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAgent_DisableInjection(t *testing.T) {
-	fakeServer := th.SetupHTTP()
-	defer fakeServer.Teardown()
-
-	portFixture := `{
-		"port": {
-			"id": "550e8400-e29b-41d4-a716-446655440000",
-			"network_id": "660e8400-e29b-41d4-a716-446655440000",
-			"tenant_id": "26a7980765d0414dbc1fc1f88cdb7e6e"
-        }
-}`
-
 	a := &Agent{
-		neutron: fake.ServiceClient(fakeServer),
 		haproxy: haproxy.NewFakeHaproxy(),
 	}
 	si := &models.ServiceInjection{
 		PortId:  strfmt.UUID("550e8400-e29b-41d4-a716-446655440000"),
 		Network: strfmt.UUID("660e8400-e29b-41d4-a716-446655440000"),
 	}
-	fixture.SetupHandler(t, fakeServer, "/v2.0/ports/"+si.PortId.String(), "GET",
-		"", portFixture, http.StatusOK)
 
 	assert.NoError(t, a.DisableInjection(si))
 

--- a/internal/controller/service.go
+++ b/internal/controller/service.go
@@ -635,7 +635,10 @@ func commonEndpointsActionHandler(pool db.PgxIface, body any, _ any) ([]*models.
 		Where("id = ?", serviceId).
 		MustSql()
 	var host string
-	if err = pgxscan.Get(httpRequest.Context(), pool, &host, sql, args...); err == nil {
+	if err = pgxscan.Get(httpRequest.Context(), pool, &host, sql, args...); err != nil {
+		log.WithError(err).WithField("service_id", serviceId).
+			Error("Failed to get host for notification, endpoints may not be processed")
+	} else {
 		// Notify agent for each updated endpoint
 		for _, ec := range endpointConsumers {
 			db.NotifyEndpoint(pool, host, ec.ID)


### PR DESCRIPTION

- **F5 Agent**: Optimize `populateEndpointPorts` with O(n+m) map-based lookups instead of O(n*m) nested loops
- **F5 Agent**: Allow endpoints being deleted to proceed even if their Neutron port was manually deleted
- **F5/NI Agents**: Retain Neutron ports on rejection to enable re-acceptance without port recreation
- **Server**: Log error when notification host lookup fails (previously silent failure)