### PR TITLE
fix(migrate): support pool_max_conns in connection string

### DIFF
--- a/cmd/archer-migrate/main.go
+++ b/cmd/archer-migrate/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jessevdk/go-flags"
 	log "github.com/sirupsen/logrus"
 	"github.com/z0ne-dev/mgx/v2"
@@ -35,7 +36,13 @@ func main() {
 
 	config.ParseConfig(parser)
 
-	conn, err := pgx.Connect(context.Background(), config.Global.Database.Connection)
+	// Use pgxpool.ParseConfig to properly handle pool_* parameters in connection string,
+	// then use the underlying ConnConfig for a single connection
+	poolConfig, err := pgxpool.ParseConfig(config.Global.Database.Connection)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	conn, err := pgx.ConnectConfig(context.Background(), poolConfig.ConnConfig)
 	if err != nil {
 		log.Fatal(err.Error())
 	}


### PR DESCRIPTION
## Summary
- Use `pgxpool.ParseConfig` to parse connection strings in archer-migrate
- Fixes "unrecognized configuration parameter pool_max_conns" error when connection string includes pool parameters

## Problem
The migration tool used `pgx.Connect()` directly, which doesn't understand pgxpool-specific parameters like `pool_max_conns`. When users specified these parameters in their connection string, PostgreSQL would reject them with SQLSTATE 42704.

## Solution
Use `pgxpool.ParseConfig()` which properly extracts pool parameters, then use the underlying `ConnConfig` for the single connection.

## Test plan
- [x] `make check` passes
- [x] Builds successfully