### PR TITLE
optimize ppv2 irule for performance

### DIFF
--- a/internal/agent/f5/as3/proxy_protocol_2.go
+++ b/internal/agent/f5/as3/proxy_protocol_2.go
@@ -8,10 +8,35 @@ var pp2 = `
 # serverside PROXY Protocol V2 implementation
 # https://github.com/haproxy/haproxy/blob/ffdf6a32a7413d5bcf9223c3556b765b5e456a69/doc/proxy-protocol.txt
 
+when RULE_INIT {
+    # https://github.com/haproxy/haproxy/blob/ffdf6a32a7413d5bcf9223c3556b765b5e456a69/doc/proxy-protocol.txt#L335
+    # proxy protocol version 2 signature (12 bytes)
+    set static::pp2_header_signature \x0d\x0a\x0d\x0a\x00\x0d\x0a\x51\x55\x49\x54\x0a
+
+    # https://github.com/haproxy/haproxy/blob/ffdf6a32a7413d5bcf9223c3556b765b5e456a69/doc/proxy-protocol.txt#L340-L358
+    # proxy protocol version and command (\x2 -> proxy protocol version is 2; \x1 -> command is PROXY)
+    #set pp2_header_byte13 [expr {(0x02 << 4) + 0x01}]
+    set static::pp2_header_byte13 \x21
+
+    # https://github.com/haproxy/haproxy/blob/ffdf6a32a7413d5bcf9223c3556b765b5e456a69/doc/proxy-protocol.txt#L360-L433
+    # transport protocol and address family (\x1 -> transport protocol is STREAM/TCP; \x1 -> address family is AF_INET/ipv4)
+    #set pp2_header_byte14 [expr {(0x01 << 4) + 0x01}]
+    set static::pp2_header_byte14 \x11
+
+    # proxy protocol length
+    # number of following bytes part of the header in network endian order
+    # https://github.com/haproxy/haproxy/blob/ffdf6a32a7413d5bcf9223c3556b765b5e456a69/doc/proxy-protocol.txt#L441-L449
+    #                                           $pp_proxy_addr len is 12
+    set static::pp2_header_byte1516 \x00\x33
+
+}
+
+# serverside PROXY Protocol V2 implementation
+# https://github.com/haproxy/haproxy/blob/ffdf6a32a7413d5bcf9223c3556b765b5e456a69/doc/proxy-protocol.txt
+
 # converts an ipv4 ip in dotted notation into 4 binary strings with one byte in hex each
 proc ip2hex { ip } {
-    set octets [split [getfield $ip % 1] .]
-    return [binary format c4 $octets]
+    return [binary format c4 [scan $ip "%d.%d.%d.%d\%%*s"]]
 }
 
 # converts an 2Byte integer to 2 binary strings with one byte in hex each
@@ -46,43 +71,28 @@ proc tlv_sapcc {uuid4} {
     return [call tlv \xec [binary format A* $uuid4]]
 }
 
-when SERVER_CONNECTED priority 900 {
+when SERVER_CONNECTED priority 900 timing on {
     # create TLV type 5
     #set pp2_tlv [call tlv_type5]
     #set pp2_tlv [call tlv_sapcc {497f6eca-6276-4993-bfeb-53cbbbba6f08}]
-    set pp2_tlv_strlen [string length [virtual name]]
-    set pp2_tlv [call tlv_sapcc [string range [virtual name] [expr { $pp2_tlv_strlen - 36 }] $pp2_tlv_strlen]]
-
-    # https://github.com/haproxy/haproxy/blob/ffdf6a32a7413d5bcf9223c3556b765b5e456a69/doc/proxy-protocol.txt#L335
-    # proxy protocol version 2 signature (12 bytes)
-    set pp2_header_signature \x0d\x0a\x0d\x0a\x00\x0d\x0a\x51\x55\x49\x54\x0a
-
-    # https://github.com/haproxy/haproxy/blob/ffdf6a32a7413d5bcf9223c3556b765b5e456a69/doc/proxy-protocol.txt#L340-L358
-    # proxy protocol version and command (\x2 -> proxy protocol version is 2; \x1 -> command is PROXY)
-    #set pp2_header_byte13 [expr {(0x02 << 4) + 0x01}]
-    set pp2_header_byte13 \x21
-
-    # https://github.com/haproxy/haproxy/blob/ffdf6a32a7413d5bcf9223c3556b765b5e456a69/doc/proxy-protocol.txt#L360-L433
-    # transport protocol and address family (\x1 -> transport protocol is STREAM/TCP; \x1 -> address family is AF_INET/ipv4)
-    #set pp2_header_byte14 [expr {(0x01 << 4) + 0x01}]
-    set pp2_header_byte14 \x11
+    #set pp2_tlv [call tlv_sapcc [string range [virtual name] end-35 end]]
 
     # proxy protocol addr
-    set pp_proxy_addr [call proxy_addr]
+    #set pp_proxy_addr [call proxy_addr]
 
     # proxy protocol length
     # number of following bytes part of the header in network endian order
     # https://github.com/haproxy/haproxy/blob/ffdf6a32a7413d5bcf9223c3556b765b5e456a69/doc/proxy-protocol.txt#L441-L449
     #                                           $pp_proxy_addr len is 12
     # NOTE: if the TLV length is static, it could be pre-calculated similar to pp_proxy_addr
-    set pp2_header_byte1516 [binary format S [expr {12 + [string length $pp2_tlv]}]]
+    #set pp2_header_byte1516 [binary format S [expr {12 + [string length $pp2_tlv]}]]
 
     # construct pp2_header
-    set pp2_header ${pp2_header_signature}${pp2_header_byte13}${pp2_header_byte14}$pp2_header_byte1516$pp_proxy_addr$pp2_tlv
-
+    # set pp2_header [binary format a*a*a*a*a*a* $static::pp2_header_signature $static::pp2_header_byte13 $static::pp2_header_byte14 $static::pp2_header_byte1516 [call proxy_addr] [call tlv_sapcc [string range [virtual name] end-35 end]]]
+    #set pp2_header ${static::pp2_header_signature}${static::pp2_header_byte13}${static::pp2_header_byte14}${static::pp2_header_byte1516}[call proxy_addr][call tlv_sapcc [string range [virtual name] end-35 end]]
     # ensure pp header conversion of \x00 to NUL(0x00), not c080
-    binary scan $pp2_header H* tmp
+    # binary scan $pp2_header H* tmp
 
     # send pp
-    TCP::respond $pp2_header
+    TCP::respond [binary format a*a*a*a*a*a* $static::pp2_header_signature $static::pp2_header_byte13 $static::pp2_header_byte14 $static::pp2_header_byte1516 [call proxy_addr] [call tlv_sapcc [string range [virtual name] end-35 end]]]
 }`


### PR DESCRIPTION
As part of an overall performance tuning with aim to further improve latency of traffic processed by archer, the PPv2 irule was optimized to cut down on processing time. In lab tests, the adjusted irule takes now approx. 20% less CPU cycles for execution.
Functional testing in QA successful.

