### PR TITLE
feat: add promhttp instrumentation for API HTTP requests

### DIFF
--- a/internal/agent/f5/agent.go
+++ b/internal/agent/f5/agent.go
@@ -6,7 +6,6 @@ package f5
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -246,13 +245,6 @@ func (a *Agent) PendingSyncLoop() error {
 	}
 
 	return nil
-}
-
-func (a *Agent) PrometheusListenerThread() {
-	log.Infof("Serving prometheus metrics to %s/metrics", config.Global.Default.PrometheusListen)
-	if err := http.ListenAndServe(config.Global.Default.PrometheusListen, nil); err != nil {
-		log.Fatal(err.Error())
-	}
 }
 
 // UpdateHeartbeat updates the agent's heartbeat in the database.

--- a/restapi/configure_archer.go
+++ b/restapi/configure_archer.go
@@ -51,6 +51,23 @@ import (
 var (
 	// SwaggerSpec make parsed swaggerspec available globally
 	SwaggerSpec *loads.Document
+
+	httpRequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "http_request_duration_seconds",
+		Help:    "Duration of HTTP requests in seconds.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"method", "code"})
+
+	httpRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "http_requests_total",
+		Help: "Total number of HTTP requests.",
+	}, []string{"method", "code"})
+
+	httpResponseSize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "http_response_size_bytes",
+		Help:    "Size of HTTP responses in bytes.",
+		Buckets: prometheus.ExponentialBuckets(100, 10, 7),
+	}, []string{"method", "code"})
 )
 
 func configureFlags(api *operations.ArcherAPI) {
@@ -90,6 +107,7 @@ func configureAPI(api *operations.ArcherAPI) http.Handler {
 
 		collector := pgxpoolprometheus.NewCollector(pool, map[string]string{"db_name": connConfig.ConnConfig.Database})
 		prometheus.MustRegister(collector)
+		prometheus.MustRegister(httpRequestDuration, httpRequestsTotal, httpResponseSize)
 	}
 
 	// Keystone authentication
@@ -253,6 +271,13 @@ func setupGlobalMiddleware(handler http.Handler) http.Handler {
 			AllowedMethods: []string{"HEAD", "GET", "POST", "PUT", "DELETE"},
 			AllowedHeaders: []string{"Content-Type", "User-Agent", "X-Auth-Token"},
 		}).Handler(handler)
+	}
+
+	// Prometheus HTTP metrics instrumentation
+	if config.Global.Default.Prometheus {
+		handler = promhttp.InstrumentHandlerDuration(httpRequestDuration,
+			promhttp.InstrumentHandlerCounter(httpRequestsTotal,
+				promhttp.InstrumentHandlerResponseSize(httpResponseSize, handler)))
 	}
 
 	// Pass via sentry handler


### PR DESCRIPTION
Instrument the API server with promhttp middleware to expose http_request_duration_seconds, http_requests_total, and http_response_size_bytes metrics labeled by method and code.

Also remove unused PrometheusListenerThread from f5 agent.