### PR TITLE
feat(service): honor project_id query parameter in GetService

### DIFF
--- a/internal/controller/service.go
+++ b/internal/controller/service.go
@@ -70,6 +70,11 @@ func (c *Controller) GetServiceHandler(params service.GetServiceParams, principa
 			})
 	}
 
+	// Honor optional project_id query filter: narrow results to a specific project.
+	if params.ProjectID != nil && len(*params.ProjectID) > 0 {
+		q = q.Where(sq.Eq{"project_id": *params.ProjectID})
+	}
+
 	pagination := db.Pagination(params)
 	sql, args, err := pagination.Query(c.pool, q)
 	if err != nil {


### PR DESCRIPTION
The `GET /service` endpoint already scopes results via the token's project
(`X-Project-Id` header), but also returns public and `RBAC`-shared services
from other projects. When a caller passes` ?project_id=`, that filter was
silently ignored.
