### PR TITLE
fix(notifier): detach ScheduleImmediate async work from request context

### DIFF
--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -22,6 +22,10 @@ import (
 // notificationLockID is a fixed lock ID for digest notification scheduling.
 const notificationLockID = 8675310
 
+// immediateNotificationTimeout bounds the async work in ScheduleImmediate so a
+// hung DB query or Campfire HTTP call cannot delay scheduler shutdown.
+const immediateNotificationTimeout = 30 * time.Second
+
 type Config struct {
 	CampfireURL    string
 	TemplatePath   string
@@ -97,12 +101,17 @@ func (n *Notifier) Stop() error {
 // The job runs asynchronously after the calling HTTP handler returns, so the caller's
 // request-scoped context (which net/http cancels on handler return) must not be captured
 // directly. We detach cancellation with context.WithoutCancel while preserving any
-// request-scoped values (trace IDs, logging fields).
+// request-scoped values (trace IDs, logging fields), then re-attach a bounded
+// timeout so the async DB lookup and Campfire HTTP call cannot run unbounded
+// and stall scheduler shutdown.
 func (n *Notifier) ScheduleImmediate(ctx context.Context, pool db.PgxIface, serviceID strfmt.UUID, ep *models.Endpoint) {
 	asyncCtx := context.WithoutCancel(ctx)
 	_, err := n.gocronScheduler.NewJob(
 		gocron.OneTimeJob(gocron.OneTimeJobStartImmediately()),
 		gocron.NewTask(func() {
+			taskCtx, cancel := context.WithTimeout(asyncCtx, immediateNotificationTimeout)
+			defer cancel()
+
 			sql, args := db.Select("name", "project_id").
 				From("service").
 				Where("id = ?", serviceID).
@@ -110,7 +119,7 @@ func (n *Notifier) ScheduleImmediate(ctx context.Context, pool db.PgxIface, serv
 
 			var serviceName string
 			var ownerProjectID string
-			if err := pool.QueryRow(asyncCtx, sql, args...).Scan(&serviceName, &ownerProjectID); err != nil {
+			if err := pool.QueryRow(taskCtx, sql, args...).Scan(&serviceName, &ownerProjectID); err != nil {
 				log.WithError(err).WithField("service_id", serviceID).Error("Failed to look up service for notification")
 				return
 			}
@@ -125,7 +134,7 @@ func (n *Notifier) ScheduleImmediate(ctx context.Context, pool db.PgxIface, serv
 				},
 			}
 
-			if err := n.SendNotification(asyncCtx, ownerProjectID, data); err != nil {
+			if err := n.SendNotification(taskCtx, ownerProjectID, data); err != nil {
 				log.WithError(err).WithFields(log.Fields{
 					"service_id":  serviceID,
 					"endpoint_id": ep.ID,

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -93,7 +93,13 @@ func (n *Notifier) Stop() error {
 }
 
 // ScheduleImmediate creates a one-shot job that sends an immediate notification for a new pending endpoint.
+//
+// The job runs asynchronously after the calling HTTP handler returns, so the caller's
+// request-scoped context (which net/http cancels on handler return) must not be captured
+// directly. We detach cancellation with context.WithoutCancel while preserving any
+// request-scoped values (trace IDs, logging fields).
 func (n *Notifier) ScheduleImmediate(ctx context.Context, pool db.PgxIface, serviceID strfmt.UUID, ep *models.Endpoint) {
+	asyncCtx := context.WithoutCancel(ctx)
 	_, err := n.gocronScheduler.NewJob(
 		gocron.OneTimeJob(gocron.OneTimeJobStartImmediately()),
 		gocron.NewTask(func() {
@@ -104,7 +110,7 @@ func (n *Notifier) ScheduleImmediate(ctx context.Context, pool db.PgxIface, serv
 
 			var serviceName string
 			var ownerProjectID string
-			if err := pool.QueryRow(ctx, sql, args...).Scan(&serviceName, &ownerProjectID); err != nil {
+			if err := pool.QueryRow(asyncCtx, sql, args...).Scan(&serviceName, &ownerProjectID); err != nil {
 				log.WithError(err).WithField("service_id", serviceID).Error("Failed to look up service for notification")
 				return
 			}
@@ -119,7 +125,7 @@ func (n *Notifier) ScheduleImmediate(ctx context.Context, pool db.PgxIface, serv
 				},
 			}
 
-			if err := n.SendNotification(ctx, ownerProjectID, data); err != nil {
+			if err := n.SendNotification(asyncCtx, ownerProjectID, data); err != nil {
 				log.WithError(err).WithFields(log.Fields{
 					"service_id":  serviceID,
 					"endpoint_id": ep.ID,

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -98,18 +98,20 @@ func (n *Notifier) Stop() error {
 
 // ScheduleImmediate creates a one-shot job that sends an immediate notification for a new pending endpoint.
 //
-// The job runs asynchronously after the calling HTTP handler returns, so the caller's
-// request-scoped context (which net/http cancels on handler return) must not be captured
-// directly. We detach cancellation with context.WithoutCancel while preserving any
-// request-scoped values (trace IDs, logging fields), then re-attach a bounded
-// timeout so the async DB lookup and Campfire HTTP call cannot run unbounded
-// and stall scheduler shutdown.
-func (n *Notifier) ScheduleImmediate(ctx context.Context, pool db.PgxIface, serviceID strfmt.UUID, ep *models.Endpoint) {
-	asyncCtx := context.WithoutCancel(ctx)
+// The job runs asynchronously after the calling HTTP handler returns. Rather than capturing
+// the caller's request-scoped context (which net/http cancels on handler return), the task
+// receives a job-scoped context from gocron. That context is independent of the caller's
+// lifetime and is cancelled when the scheduler shuts down, so in-flight tasks short-circuit
+// cleanly on shutdown. We re-attach a bounded timeout so the DB lookup and Campfire HTTP
+// call cannot run unbounded.
+//
+// The ctx parameter is intentionally unused: it exists for API symmetry with other notifier
+// methods and to keep the call site in controller/endpoint.go natural.
+func (n *Notifier) ScheduleImmediate(_ context.Context, pool db.PgxIface, serviceID strfmt.UUID, ep *models.Endpoint) {
 	_, err := n.gocronScheduler.NewJob(
 		gocron.OneTimeJob(gocron.OneTimeJobStartImmediately()),
-		gocron.NewTask(func() {
-			taskCtx, cancel := context.WithTimeout(asyncCtx, immediateNotificationTimeout)
+		gocron.NewTask(func(ctx context.Context) {
+			taskCtx, cancel := context.WithTimeout(ctx, immediateNotificationTimeout)
 			defer cancel()
 
 			sql, args := db.Select("name", "project_id").

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -118,10 +118,12 @@ func TestNotifier_StartFailsWithoutConnection(t *testing.T) {
 }
 
 func TestNotifier_ScheduleImmediate(t *testing.T) {
-	var receivedReq CampfireRequest
+	received := make(chan CampfireRequest, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewDecoder(r.Body).Decode(&receivedReq)
+		var req CampfireRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
 		w.WriteHeader(http.StatusOK)
+		received <- req
 	}))
 	defer server.Close()
 
@@ -152,12 +154,71 @@ func TestNotifier_ScheduleImmediate(t *testing.T) {
 
 	n.ScheduleImmediate(context.Background(), mock, strfmt.UUID("svc-id-1"), ep)
 
-	assert.Eventually(t, func() bool {
-		return receivedReq.ProjectID != ""
-	}, 2*time.Second, 50*time.Millisecond)
+	select {
+	case req := <-received:
+		assert.Equal(t, "owner-project-123", req.ProjectID)
+		assert.Contains(t, req.Subject, "pending approval")
+		assert.Contains(t, req.MailText, "my-service")
+	case <-time.After(2 * time.Second):
+		t.Fatal("immediate notification was not sent")
+	}
 
-	assert.Equal(t, "owner-project-123", receivedReq.ProjectID)
-	assert.Contains(t, receivedReq.Subject, "pending approval")
-	assert.Contains(t, receivedReq.MailText, "my-service")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestNotifier_ScheduleImmediate_ParentContextCancelled verifies that cancelling the
+// caller's context after ScheduleImmediate returns does NOT prevent the async job from
+// completing. This regresses against an earlier bug where the HTTP request context was
+// captured into the gocron task closure: net/http cancels that ctx on handler return,
+// causing both the DB lookup and the Campfire HTTP call to fail with context canceled.
+func TestNotifier_ScheduleImmediate_ParentContextCancelled(t *testing.T) {
+	received := make(chan CampfireRequest, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req CampfireRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.WriteHeader(http.StatusOK)
+		received <- req
+	}))
+	defer server.Close()
+
+	mock, err := pgxmock.NewPool(pgxmock.QueryMatcherOption(pgxmock.QueryMatcherRegexp))
+	require.NoError(t, err)
+	defer mock.Close()
+
+	n, err := New(Config{
+		CampfireURL:    server.URL,
+		DigestCron:     "0 9 * * *",
+		ProviderClient: &gophercloud.ProviderClient{TokenID: "test"},
+	}, mock)
+	require.NoError(t, err)
+	n.gocronScheduler.Start()
+	defer func() { _ = n.gocronScheduler.Shutdown() }()
+
+	rows := pgxmock.NewRows([]string{"name", "project_id"}).
+		AddRow("my-service", "owner-project-123")
+	mock.ExpectQuery("SELECT .+ FROM service").
+		WithArgs(strfmt.UUID("svc-id-1")).
+		WillReturnRows(rows)
+
+	ep := &models.Endpoint{
+		ID:        "ep-id-1",
+		ProjectID: "consumer-project",
+		CreatedAt: time.Now(),
+	}
+
+	// Simulate an HTTP handler scope: parent ctx cancelled the moment the handler returns.
+	parentCtx, cancel := context.WithCancel(context.Background())
+	n.ScheduleImmediate(parentCtx, mock, strfmt.UUID("svc-id-1"), ep)
+	cancel() // cancel BEFORE the async job runs
+
+	select {
+	case req := <-received:
+		assert.Equal(t, "owner-project-123", req.ProjectID)
+		assert.Contains(t, req.Subject, "pending approval")
+		assert.Contains(t, req.MailText, "my-service")
+	case <-time.After(2 * time.Second):
+		t.Fatal("async notification job did not complete after parent context was cancelled")
+	}
+
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -210,10 +210,10 @@ func TestNotifier_ScheduleImmediate_ParentContextCancelled(t *testing.T) {
 		CreatedAt: time.Now(),
 	}
 
-	// Cancel BEFORE scheduling so the gocron task is guaranteed to observe
-	// an already-cancelled parent. Without context.WithoutCancel in
-	// ScheduleImmediate, the task's DB lookup would fail with "context
-	// canceled" and the Campfire HTTP server would never receive a request.
+	// Cancel BEFORE scheduling to verify that ScheduleImmediate still enqueues
+	// work that runs independently of the caller's cancelled context. The job
+	// should still complete its DB lookup and send the Campfire request even
+	// though the parent context has already been cancelled.
 	parentCtx, cancel := context.WithCancel(context.Background())
 	cancel()
 	n.ScheduleImmediate(parentCtx, mock, strfmt.UUID("svc-id-1"), ep)

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -166,11 +166,15 @@ func TestNotifier_ScheduleImmediate(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-// TestNotifier_ScheduleImmediate_ParentContextCancelled verifies that cancelling the
-// caller's context after ScheduleImmediate returns does NOT prevent the async job from
-// completing. This regresses against an earlier bug where the HTTP request context was
-// captured into the gocron task closure: net/http cancels that ctx on handler return,
-// causing both the DB lookup and the Campfire HTTP call to fail with context canceled.
+// TestNotifier_ScheduleImmediate_ParentContextCancelled pins the contract that
+// ScheduleImmediate's async work must not be tied to the caller's context lifetime.
+// In production the caller is an HTTP handler whose ctx is cancelled the moment the
+// handler returns; if the gocron task captured that ctx directly, the DB lookup and
+// Campfire send would fail with "context canceled" every time.
+//
+// The parent ctx is cancelled before scheduling so the task is guaranteed to observe
+// a cancelled parent. Cancelling after the call would race the gocron worker and
+// could let the test pass even if cancellation propagation regressed.
 func TestNotifier_ScheduleImmediate_ParentContextCancelled(t *testing.T) {
 	received := make(chan CampfireRequest, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -121,7 +121,7 @@ func TestNotifier_ScheduleImmediate(t *testing.T) {
 	received := make(chan CampfireRequest, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req CampfireRequest
-		_ = json.NewDecoder(r.Body).Decode(&req)
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
 		w.WriteHeader(http.StatusOK)
 		received <- req
 	}))
@@ -179,7 +179,7 @@ func TestNotifier_ScheduleImmediate_ParentContextCancelled(t *testing.T) {
 	received := make(chan CampfireRequest, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req CampfireRequest
-		_ = json.NewDecoder(r.Body).Decode(&req)
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
 		w.WriteHeader(http.StatusOK)
 		received <- req
 	}))

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -206,10 +206,13 @@ func TestNotifier_ScheduleImmediate_ParentContextCancelled(t *testing.T) {
 		CreatedAt: time.Now(),
 	}
 
-	// Simulate an HTTP handler scope: parent ctx cancelled the moment the handler returns.
+	// Cancel BEFORE scheduling so the gocron task is guaranteed to observe
+	// an already-cancelled parent. Without context.WithoutCancel in
+	// ScheduleImmediate, the task's DB lookup would fail with "context
+	// canceled" and the Campfire HTTP server would never receive a request.
 	parentCtx, cancel := context.WithCancel(context.Background())
+	cancel()
 	n.ScheduleImmediate(parentCtx, mock, strfmt.UUID("svc-id-1"), ep)
-	cancel() // cancel BEFORE the async job runs
 
 	select {
 	case req := <-received:


### PR DESCRIPTION
## Summary
- `Notifier.ScheduleImmediate` schedules a gocron one-shot job that runs **after** the HTTP handler returns. It captured `params.HTTPRequest.Context()`, which `net/http` cancels at handler return — so the async DB lookup and Campfire HTTP call both failed with `context canceled`. Every immediate endpoint notification was silently dropped in production.
- Use gocron's native `func(ctx context.Context)` task signature so the task receives a job-scoped context from the scheduler. That context is independent of the caller's HTTP request lifetime AND is cancelled when the scheduler shuts down, so in-flight tasks short-circuit cleanly on shutdown.
- Wrap the task ctx with a 30s `context.WithTimeout` so a stuck DB query or Campfire HTTP call cannot run unbounded and stall scheduler shutdown.
- Add a regression test that cancels the parent context before the gocron task fires. Without the fix, the test fails with `async notification job did not complete after parent context was cancelled`.
- Rewrite the existing `ScheduleImmediate` test to use a buffered channel instead of `assert.Eventually` over a shared variable, which was tripping `-race`.

## Why this matters
Found during review of #772. Affects every endpoint approval path that calls `ScheduleImmediate` — the user-visible symptom is missing Campfire/email notifications with no error returned to the API caller (the handler had already responded 200).

## Review-driven evolution
Initial fix used `context.WithoutCancel(ctx)` to detach cancellation while preserving request-scoped values. Per @notandy's review the implementation was simplified to gocron's job context, which already provides caller-detachment AND adds graceful shutdown cancellation that `WithoutCancel` did not. Verified via grep that no caller in `internal/controller/` or `internal/middlewares/` propagates request-scoped ctx values into the notifier task body, so the change is value-lossless.

## Test plan
- [x] `go test -race -count=3 ./internal/notifier/...` — passes
- [x] Regression test (`TestNotifier_ScheduleImmediate_ParentContextCancelled`) fails on main, passes here — RED-GREEN verified
- [x] `make check` linters: shellcheck, golangci-lint (0 issues), go-licence-detector, addlicense, reuse — all green