### PR TITLE
feat: add ArcherUI web frontend

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -62,6 +62,13 @@ jobs:
           VERSION="${{ steps.bump.outputs.version }}"
           sed -i "s/^  version: .*/  version: \"${VERSION}\"/" swagger.yaml
 
+      - name: Update web/package.json version
+        if: steps.check.outputs.has_changes == 'true'
+        working-directory: web
+        run: |
+          VERSION="${{ steps.bump.outputs.version }}"
+          npm version --no-git-tag-version --allow-same-version "${VERSION}"
+
       - name: Set up Go
         if: steps.check.outputs.has_changes == 'true'
         uses: actions/setup-go@v6
@@ -90,6 +97,7 @@ jobs:
             **Changes in this release:**
             - Updated CHANGELOG.md with release date
             - Updated swagger.yaml version to ${{ steps.bump.outputs.version }}
+            - Updated web/package.json version to ${{ steps.bump.outputs.version }}
 
             ### Release Notes
 

--- a/.github/workflows/web-ci.yaml
+++ b/.github/workflows/web-ci.yaml
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+# SPDX-License-Identifier: Apache-2.0
+
+name: Web CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'web/**'
+      - '.github/workflows/web-ci.yaml'
+  pull_request:
+    branches:
+      - '*'
+    paths:
+      - 'web/**'
+      - '.github/workflows/web-ci.yaml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: web
+
+jobs:
+  format-check:
+    name: Format check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          package_json_file: web/package.json
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: web/package.json
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Check formatting
+        run: pnpm check-format
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          package_json_file: web/package.json
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: web/package.json
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Typecheck
+        run: pnpm typecheck
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          package_json_file: web/package.json
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: web/package.json
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm build

--- a/.github/workflows/web-publish.yaml
+++ b/.github/workflows/web-publish.yaml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+# SPDX-License-Identifier: Apache-2.0
+
+name: Web Publish
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+defaults:
+  run:
+    working-directory: web
+
+jobs:
+  publish:
+    name: Build and publish to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          package_json_file: web/package.json
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: web/package.json
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+          registry-url: https://npm.pkg.github.com/
+          scope: '@${{ github.repository_owner }}'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Publish to GitHub Packages
+        run: |
+          set +e
+          pnpm publish --access=public --no-git-checks
+          status=$?
+          if [ "$status" -ne 0 ]; then
+            echo "::warning title=PUBLISH::pnpm publish failed (exit $status). This is expected if the version in web/package.json was not bumped for this tag."
+            exit 0
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,28 @@ repos:
         entry: sh -c "gmake check || make check"
         language: system
         pass_filenames: false
+        files: '\.go$|^go\.(mod|sum)$|^Makefile|^Makefile\.maker\.yaml$'
       - id: swagger
         name: swagger
         entry: sh -c "gmake swagger || make swagger"
         language: system
         pass_filenames: false
+        files: '^swagger\.yaml$'
       - id: go-build
         name: go build
         entry: sh -c "gmake build-all || make build-all"
         language: system
         pass_filenames: false
+        files: '\.go$|^go\.(mod|sum)$|^Makefile|^Makefile\.maker\.yaml$'
+      - id: web-format
+        name: web prettier check
+        entry: sh -c "cd web && pnpm check-format"
+        language: system
+        pass_filenames: false
+        files: '^web/.*\.(ts|tsx|md)$'
+      - id: web-typecheck
+        name: web typecheck
+        entry: sh -c "cd web && pnpm typecheck"
+        language: system
+        pass_filenames: false
+        files: '^web/.*\.(ts|tsx)$|^web/tsconfig\.json$|^web/package\.json$'

--- a/.typos.toml
+++ b/.typos.toml
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [default.extend-words]
+Hashi = "Hashi"
 recovr = "recovr"
 
 [files]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Server: immediate notification job no longer captures the HTTP request context, so the DB lookup and Campfire send no longer fail with "context canceled" once the handler returns
 
+### Added
+
+- ArcherUI: a TypeScript/React frontend for managing services, endpoints, and RBAC policies, with a topology view that visualizes the relationships between services, endpoints, and external consumers
+
 ## [2.4.1] - 2026-04-30
 
 ### Fixed

--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -75,6 +75,22 @@ reuse:
         - internal/notifier/templates/*.tmpl
       SPDX-FileCopyrightText: 'SAP SE or an SAP affiliate company'
       SPDX-License-Identifier: Apache-2.0
+    - paths:
+        - web/.gitignore
+        - web/.prettierrc
+        - web/CLAUDE.md
+        - web/README.md
+        - web/appProps.example.json
+        - web/appProps.template.json
+        - web/package.json
+        - web/package-lock.json
+        - web/pnpm-lock.yaml
+        - web/pnpm-workspace.yaml
+        - web/public/index.html
+        - web/public/mockServiceWorker.js
+        - web/tsconfig.json
+      SPDX-FileCopyrightText: 'SAP SE or an SAP affiliate company'
+      SPDX-License-Identifier: Apache-2.0
 
 verbatim: |
   mockery:
@@ -100,3 +116,4 @@ typos:
   enabled: true
   extendWords:
     recovr: recovr
+    Hashi: Hashi

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -35,3 +35,22 @@ path = [
 ]
 SPDX-FileCopyrightText = "SAP SE or an SAP affiliate company"
 SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = [
+  "web/.gitignore",
+  "web/.prettierrc",
+  "web/CLAUDE.md",
+  "web/README.md",
+  "web/appProps.example.json",
+  "web/appProps.template.json",
+  "web/package.json",
+  "web/package-lock.json",
+  "web/pnpm-lock.yaml",
+  "web/pnpm-workspace.yaml",
+  "web/public/index.html",
+  "web/public/mockServiceWorker.js",
+  "web/tsconfig.json",
+]
+SPDX-FileCopyrightText = "SAP SE or an SAP affiliate company"
+SPDX-License-Identifier = "Apache-2.0"

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,29 @@
+# Dependencies
+node_modules/
+
+# Build output
+build/
+public/build/
+
+# Dev config (contains tokens)
+appProps.json
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+.DS_Store
+
+# Claude Code
+.claude/
+
+# Logs
+*.log
+npm-debug.log*
+
+# Test coverage
+coverage/
+
+# TypeScript cache
+*.tsbuildinfo

--- a/web/.prettierrc
+++ b/web/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "arrowParens": "always",
+  "bracketSpacing": true,
+  "endOfLine": "lf",
+  "printWidth": 120,
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "es5"
+}

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -1,0 +1,103 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+ArcherUI is a TypeScript React application for managing Archer "Endpoint as a Service" resources. It allows users to create services, endpoints, and RBAC policies that privately connect OpenStack networks.
+
+## Commands
+
+```bash
+pnpm install                  # Install dependencies
+APP_PORT=8000 pnpm start      # Dev server at localhost:8000
+pnpm build                    # Production build
+pnpm typecheck                # TypeScript validation
+pnpm format                   # Prettier formatting
+```
+
+## Architecture
+
+### Entry Point
+
+- `src/index.tsx` exports `mount(container, { props })` for embedding
+- Enables MSW mocking when `props.mockAPI` is true
+- Lazy-loads `App.tsx` for code splitting
+
+### State Management
+
+- Single Zustand store in `src/store.ts`
+- `globalAPI`: endpoint, token, projectID, apiReady flag
+- UI state: modal visibility, edit targets, delete targets
+- Access via `useStore()` hook directly (no context needed)
+
+### API Layer
+
+- All React Query hooks in `src/api.ts`
+- Hooks read endpoint/token from Zustand store
+- Pattern: `useServices()`, `useCreateService()`, `useDeleteService()`, etc.
+- Automatic cache invalidation on mutations
+
+### Routing
+
+- HashRouter in `src/Routes.tsx`
+- Three tabs: Services, Endpoints, RBAC
+- Detail panels open as nested routes (e.g., `/services/:id`)
+
+### Types
+
+- All API types in `src/types.ts`, derived from `swagger.yaml`
+- Key types: `Service`, `Endpoint`, `RBACPolicy`, `AppProps`
+
+## Key Patterns
+
+### Adding a new API endpoint
+
+1. Add types to `src/types.ts`
+2. Add query/mutation hook to `src/api.ts`
+3. Use the hook in components
+
+### Adding a new view
+
+1. Create component in `src/components/`
+2. Add route in `src/Routes.tsx`
+3. Add tab in the `Nav` component
+
+### Modal pattern
+
+```tsx
+// Open modal
+openServiceModal(serviceToEdit); // or null for create
+
+// In component, check store
+const { showServiceModal, editService, closeModals } = useStore();
+if (showServiceModal) return <ServiceForm />;
+```
+
+## Testing with Mock API
+
+Set `mockAPI: true` in `appProps.json`. Mock handlers are in `src/mocks/handlers.ts` with fixture data inline.
+
+**Note:** Changes to `appProps.json` require restarting the dev server—they are not auto-detected.
+
+## File Structure
+
+```
+src/
+├── index.tsx          # Mount function
+├── App.tsx            # QueryClient + AppShell providers
+├── Routes.tsx         # Navigation + routing
+├── store.ts           # Zustand store
+├── api.ts             # React Query hooks
+├── types.ts           # TypeScript types
+├── styles.css         # Tailwind import
+├── components/
+│   ├── ServiceList.tsx, ServiceDetail.tsx, ServiceForm.tsx
+│   ├── EndpointList.tsx, EndpointDetail.tsx, EndpointForm.tsx
+│   ├── RBACList.tsx, RBACForm.tsx
+│   ├── StatusBadge.tsx
+│   └── DeleteModal.tsx
+└── mocks/
+    ├── browser.ts     # MSW setup
+    └── handlers.ts    # Mock API responses
+```

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,101 @@
+# ArcherUI
+
+React UI for **Archer** - an "Endpoint as a Service" API that privately connects services across OpenStack networks.
+
+## Features
+
+- **Services**: Create, view, edit, and delete private/public services
+- **Endpoints**: Manage endpoints that connect to services
+- **RBAC Policies**: Control service visibility across projects
+- **Accept/Reject**: Approve or deny endpoint connection requests
+
+## Quick Start
+
+1. Install dependencies:
+
+```bash
+pnpm install
+```
+
+2. Create `appProps.json` in the root directory (copy from example):
+
+```bash
+cp appProps.example.json appProps.json
+```
+
+Then edit `appProps.json` with your configuration:
+
+```json
+{
+  "endpoint": "https://archer-api.example.com/v1",
+  "projectID": "your-project-id",
+  "token": "your-keystone-token",
+  "canEdit": true,
+  "mockAPI": true,
+  "theme": "theme-dark"
+}
+```
+
+Set `mockAPI: true` to run with mock data (no real Archer backend needed).
+
+3. Run the dev server:
+
+```bash
+APP_PORT=8000 pnpm start
+```
+
+4. Open http://localhost:8000
+
+## Configuration
+
+| Field       | Type    | Description                                   |
+| ----------- | ------- | --------------------------------------------- |
+| `endpoint`  | string  | Archer API base URL                           |
+| `projectID` | string  | OpenStack project ID                          |
+| `token`     | string  | Keystone auth token                           |
+| `canEdit`   | boolean | Enable create/edit/delete actions             |
+| `mockAPI`   | boolean | Use mock data (no real backend needed)        |
+| `theme`     | string  | `theme-dark` or `theme-light`                 |
+| `embedded`  | boolean | Hide page header when embedded in another app |
+
+## Scripts
+
+```bash
+pnpm start          # Dev server with hot reload
+pnpm build          # Production build to build/
+pnpm typecheck      # TypeScript validation
+pnpm format         # Prettier formatting
+```
+
+## Architecture
+
+```
+src/
+├── index.tsx      # Mount function (entry point)
+├── App.tsx        # Providers setup (QueryClient, AppShell)
+├── Routes.tsx     # Tab navigation + React Router
+├── store.ts       # Zustand state (API config, UI modals)
+├── api.ts         # React Query hooks for all endpoints
+├── types.ts       # TypeScript types from Archer API spec
+├── components/    # UI components
+└── mocks/         # MSW handlers for development
+```
+
+### API Endpoints Implemented
+
+**Services**: `GET/POST /service`, `GET/PUT/DELETE /service/{id}`, `GET /service/{id}/endpoints`, `PUT /service/{id}/accept_endpoints`, `PUT /service/{id}/reject_endpoints`
+
+**Endpoints**: `GET/POST /endpoint`, `GET/PUT/DELETE /endpoint/{id}`
+
+**RBAC**: `GET/POST /rbac-policies`, `GET/PUT/DELETE /rbac-policies/{id}`
+
+## Tech Stack
+
+- React 19 + TypeScript
+- Zustand (state management)
+- TanStack Query (data fetching)
+- React Router 7
+- Juno UI Components
+- Tailwind CSS
+- esbuild (bundler)
+- MSW (API mocking)

--- a/web/appProps.example.json
+++ b/web/appProps.example.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "https://archer-api.example.com/v1",
+  "projectID": "your-project-id",
+  "token": "your-keystone-token",
+  "canEdit": true,
+  "mockAPI": true,
+  "theme": "theme-dark"
+}

--- a/web/appProps.template.json
+++ b/web/appProps.template.json
@@ -1,0 +1,11 @@
+{
+  "endpoint": "",
+  "projectID": "",
+  "token": "",
+  "canEdit": true,
+  "mockAPI": true,
+  "theme": "theme-dark",
+  "embedded": false,
+  "archerctlUrl": "https://github.com/sapcc/archer/releases/latest",
+  "docsUrl": "https://sapcc.github.io/archer/"
+}

--- a/web/babel.config.js
+++ b/web/babel.config.js
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+module.exports = {
+  env: {
+    test: {
+      presets: ["@babel/preset-env", "@babel/preset-react"],
+      plugins: [["babel-plugin-transform-import-meta", { module: "ES6" }]],
+    },
+  },
+};

--- a/web/devserver.js
+++ b/web/devserver.js
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+// Dev server with proxy support for Neutron API (CORS bypass)
+// Usage: node devserver.js
+
+const http = require("node:http");
+const https = require("node:https");
+const fs = require("node:fs/promises");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+
+const APP_PORT = parseInt(process.env.APP_PORT || "8000");
+const ESBUILD_PORT = APP_PORT + 1;
+
+// Read appProps to get neutronEndpoint
+async function getNeutronEndpoint() {
+  try {
+    const content = await fs.readFile("./appProps.json", "utf-8");
+    const props = JSON.parse(content);
+    return props.neutronEndpoint || null;
+  } catch {
+    return null;
+  }
+}
+
+// Proxy request to target URL
+function proxyRequest(targetUrl, req, res) {
+  const url = new URL(targetUrl);
+  const isHttps = url.protocol === "https:";
+  const client = isHttps ? https : http;
+
+  const proxyReq = client.request(
+    {
+      hostname: url.hostname,
+      port: url.port || (isHttps ? 443 : 80),
+      path: url.pathname + url.search,
+      method: req.method,
+      headers: {
+        ...req.headers,
+        host: url.host,
+      },
+    },
+    (proxyRes) => {
+      // Add CORS headers
+      res.writeHead(proxyRes.statusCode, {
+        ...proxyRes.headers,
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "GET, POST, PUT, DELETE, OPTIONS",
+        "access-control-allow-headers": "X-Auth-Token, Content-Type, Accept",
+      });
+      proxyRes.pipe(res);
+    }
+  );
+
+  proxyReq.on("error", (err) => {
+    console.error("Proxy error:", err.message);
+    res.writeHead(502);
+    res.end(`Proxy error: ${err.message}`);
+  });
+
+  req.pipe(proxyReq);
+}
+
+// Forward request to esbuild dev server
+function forwardToEsbuild(req, res) {
+  const proxyReq = http.request(
+    {
+      hostname: "127.0.0.1",
+      port: ESBUILD_PORT,
+      path: req.url,
+      method: req.method,
+      headers: req.headers,
+    },
+    (proxyRes) => {
+      res.writeHead(proxyRes.statusCode, proxyRes.headers);
+      proxyRes.pipe(res);
+    }
+  );
+
+  proxyReq.on("error", (err) => {
+    res.writeHead(502);
+    res.end(`esbuild server error: ${err.message}`);
+  });
+
+  req.pipe(proxyReq);
+}
+
+async function startServer() {
+  const neutronEndpoint = await getNeutronEndpoint();
+
+  if (neutronEndpoint) {
+    console.log(`\x1b[36mNeutron proxy enabled: /proxy/neutron/* -> ${neutronEndpoint}/*\x1b[0m`);
+  }
+
+  // Start esbuild in background
+  const esbuild = spawn("node", ["esbuild.config.js", "--serve", "--watch"], {
+    env: { ...process.env, PORT: ESBUILD_PORT.toString(), NODE_ENV: "development" },
+    stdio: "inherit",
+  });
+
+  esbuild.on("error", (err) => {
+    console.error("Failed to start esbuild:", err);
+    process.exit(1);
+  });
+
+  // Create proxy server
+  const server = http.createServer(async (req, res) => {
+    // Handle CORS preflight
+    if (req.method === "OPTIONS") {
+      res.writeHead(204, {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "GET, POST, PUT, DELETE, OPTIONS",
+        "access-control-allow-headers": "X-Auth-Token, Content-Type, Accept",
+        "access-control-max-age": "86400",
+      });
+      res.end();
+      return;
+    }
+
+    // Proxy Neutron requests
+    if (req.url.startsWith("/proxy/neutron/") && neutronEndpoint) {
+      const targetPath = req.url.replace("/proxy/neutron", "");
+      const targetUrl = neutronEndpoint + targetPath;
+      console.log(`\x1b[35m[proxy]\x1b[0m ${req.method} ${targetUrl}`);
+      proxyRequest(targetUrl, req, res);
+      return;
+    }
+
+    // Forward everything else to esbuild
+    forwardToEsbuild(req, res);
+  });
+
+  server.listen(APP_PORT, () => {
+    console.log(`\x1b[32mDev server running at http://localhost:${APP_PORT}\x1b[0m`);
+  });
+
+  // Cleanup on exit
+  process.on("SIGINT", () => {
+    esbuild.kill();
+    server.close();
+    process.exit();
+  });
+}
+
+startServer();

--- a/web/esbuild.config.js
+++ b/web/esbuild.config.js
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+const esbuild = require("esbuild");
+const fs = require("node:fs/promises");
+const pkg = require("./package.json");
+const postcss = require("postcss");
+const sass = require("sass");
+const { transform } = require("@svgr/core");
+const url = require("postcss-url");
+const tailwindcss = require("@tailwindcss/postcss");
+const autoprefixer = require("autoprefixer");
+
+if (!/.+\/.+\.js/.test(pkg.module)) throw new Error("module value is incorrect, use DIR/FILE.js like build/index.js");
+
+const isProduction = process.env.NODE_ENV === "production";
+const IGNORE_EXTERNALS = process.env.IGNORE_EXTERNALS === "true";
+let outfile = `${isProduction ? "" : "public/"}${pkg.main || pkg.module}`;
+let outdir = outfile.slice(0, outfile.lastIndexOf("/"));
+const args = process.argv.slice(2);
+const watch = args.indexOf("--watch") >= 0;
+const serve = args.indexOf("--serve") >= 0;
+
+const green = "\x1b[32m%s\x1b[0m";
+const yellow = "\x1b[33m%s\x1b[0m";
+const clear = "\033c";
+
+const build = async () => {
+  await fs.rm(outdir, { recursive: true, force: true });
+  await fs.mkdir(outdir, { recursive: true });
+
+  let ctx = await esbuild.context({
+    bundle: true,
+    minify: isProduction,
+    treeShaking: true,
+    legalComments: isProduction ? "none" : "inline",
+    drop: isProduction ? ["console", "debugger"] : [],
+    target: ["es2022"],
+    format: "esm",
+    platform: "browser",
+    loader: { ".ts": "ts", ".tsx": "tsx" },
+    sourcemap: !isProduction,
+    external: isProduction && !IGNORE_EXTERNALS ? Object.keys(pkg.peerDependencies || {}) : [],
+    entryPoints: [pkg.source],
+    outdir,
+    splitting: true,
+    metafile: isProduction,
+    plugins: [
+      {
+        name: "start/end",
+        setup(build) {
+          build.onStart(() => {
+            console.log(clear);
+            console.log(yellow, "Compiling...");
+          });
+          build.onEnd(() => console.log(green, "Done!"));
+        },
+      },
+
+      {
+        name: "svg-loader",
+        setup(build) {
+          build.onLoad(
+            { filter: /.\.(svg)$/, namespace: "file" },
+            async (args) => {
+              let contents = await fs.readFile(args.path);
+              let loader = "text";
+              if (args.suffix === "?url") {
+                const maxSize = 10240;
+                loader = contents.length <= maxSize ? "dataurl" : "file";
+              } else {
+                loader = "jsx";
+                contents = await transform(contents, {
+                  plugins: ["@svgr/plugin-jsx"],
+                });
+              }
+              return { contents, loader };
+            }
+          );
+        },
+      },
+
+      {
+        name: "image-loader",
+        setup(build) {
+          build.onLoad(
+            { filter: /.\.(png|jpg|jpeg|gif)$/, namespace: "file" },
+            async (args) => {
+              let contents = await fs.readFile(args.path);
+              const maxSize = 10240;
+              const loader = contents.length <= maxSize ? "dataurl" : "file";
+              return { contents, loader };
+            }
+          );
+        },
+      },
+
+      {
+        name: "parse-styles",
+        setup(build) {
+          const postcssProcessor = postcss([
+            tailwindcss,
+            autoprefixer,
+            url({
+              url: "inline",
+              maxSize: 10,
+              fallback: "copy",
+              assetsPath: "./build/assets",
+              useHash: true,
+              optimizeSvgEncode: true,
+            }),
+          ]);
+
+          build.onLoad(
+            { filter: /.\.(css|scss)$/, namespace: "file" },
+            async (args) => {
+              let content;
+              if (args.path.endsWith(".scss")) {
+                const result = await sass.compileAsync(args.path);
+                content = result.css;
+              } else {
+                content = await fs.readFile(args.path);
+              }
+
+              const { css } = await postcssProcessor.process(content, {
+                from: args.path,
+                to: outdir,
+              });
+              return { contents: css, loader: "text" };
+            }
+          );
+        },
+      },
+    ],
+  });
+
+  if (watch || serve) {
+    if (watch) await ctx.watch();
+    if (serve) {
+      await fs.copyFile(`./appProps.json`, `./public/build/appProps.json`);
+
+      let { host, port } = await ctx.serve({
+        host: "0.0.0.0",
+        port: parseInt(process.env.PORT),
+        servedir: "public",
+      });
+      console.log("serve on", `${host}:${port}`);
+    }
+  } else {
+    const result = await ctx.rebuild();
+    if (isProduction && result.metafile) {
+      await fs.writeFile(`${outdir}/meta.json`, JSON.stringify(result.metafile));
+      const analysis = await esbuild.analyzeMetafile(result.metafile, {
+        verbose: false,
+      });
+      console.log(analysis);
+    }
+    await ctx.dispose();
+  }
+};
+
+build();

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@sapcc/archer-ui",
+  "version": "2.4.1",
+  "author": "SAP SE",
+  "license": "Apache-2.0",
+  "source": "src/index.tsx",
+  "module": "build/index.js",
+  "private": false,
+  "packageManager": "pnpm@11.1.2",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "files": [
+    "build",
+    "public",
+    "LICENSE"
+  ],
+  "devDependencies": {
+    "@svgr/core": "^8.0.0",
+    "@svgr/plugin-jsx": "^8.0.0",
+    "@tanstack/react-query": "^5.96.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "autoprefixer": "^10.4.2",
+    "postcss": "^8.4.21",
+    "postcss-url": "^10.1.3",
+    "prettier": "^3.2.5",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "sass": "^1.60.0",
+    "tailwindcss": "^4.1.11",
+    "typescript": "^6.0.3",
+    "zustand": "^5.0.12"
+  },
+  "dependencies": {
+    "@cloudoperators/juno-ui-components": "^6.2.0",
+    "@tailwindcss/postcss": "^4.1.11",
+    "@xyflow/react": "^12.10.2",
+    "esbuild": "^0.28.0",
+    "msw": "^2.6.6",
+    "react-router": "^7.5.1"
+  },
+  "scripts": {
+    "build": "NODE_ENV=production node esbuild.config.js",
+    "start": "APP_PORT=${APP_PORT:-8000} node devserver.js",
+    "start:simple": "PORT=$APP_PORT NODE_ENV=development node esbuild.config.js --serve --watch",
+    "format": "prettier --log-level warn --write \"**/*.{ts,tsx,md}\"",
+    "check-format": "prettier --log-level warn --check \"**/*.{ts,tsx,md}\"",
+    "typecheck": "tsc --noEmit"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
+  }
+}

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -1,0 +1,2339 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+overrides:
+  minimatch@<3.1.4: ^3.1.4
+
+importers:
+
+  .:
+    dependencies:
+      '@cloudoperators/juno-ui-components':
+        specifier: ^6.2.0
+        version: 6.4.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tailwindcss/postcss':
+        specifier: ^4.1.11
+        version: 4.3.0
+      '@xyflow/react':
+        specifier: ^12.10.2
+        version: 12.10.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      esbuild:
+        specifier: ^0.28.0
+        version: 0.28.0
+      msw:
+        specifier: ^2.6.6
+        version: 2.14.6(@types/node@25.9.0)(typescript@6.0.3)
+      react-router:
+        specifier: ^7.5.1
+        version: 7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+    devDependencies:
+      '@svgr/core':
+        specifier: ^8.0.0
+        version: 8.1.0(typescript@6.0.3)
+      '@svgr/plugin-jsx':
+        specifier: ^8.0.0
+        version: 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
+      '@tanstack/react-query':
+        specifier: ^5.96.0
+        version: 5.100.10(react@19.2.6)
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      autoprefixer:
+        specifier: ^10.4.2
+        version: 10.5.0(postcss@8.5.14)
+      postcss:
+        specifier: ^8.4.21
+        version: 8.5.14
+      postcss-url:
+        specifier: ^10.1.3
+        version: 10.1.3(postcss@8.5.14)
+      prettier:
+        specifier: ^3.2.5
+        version: 3.8.3
+      react:
+        specifier: ^19.2.4
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.6(react@19.2.6)
+      sass:
+        specifier: ^1.60.0
+        version: 1.99.0
+      tailwindcss:
+        specifier: ^4.1.11
+        version: 4.3.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      zustand:
+        specifier: ^5.0.12
+        version: 5.0.13(@types/react@19.2.14)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
+
+packages:
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.3':
+    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@cloudoperators/juno-ui-components@6.4.0':
+    resolution: {integrity: sha512-6/oGukKDwJ+IXeNPs9ktzqK+FsbrJLPIkGDc6xIwbJKQVGTy23p2AdnlkghaA0mAl4o4RpPxQsMsR2xL3aQSgA==}
+    engines: {node: '>=20.12.0', pnpm: '>=8.0.0'}
+    peerDependencies:
+      react: ^19.1.0
+      react-dom: ^19.1.0
+
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@inquirer/ansi@2.0.5':
+    resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/confirm@6.0.13':
+    resolution: {integrity: sha512-wkGPC7yJ5WJk1DJ5SX7fzk+gfj4BM8cf5dDDi71B/551xHrdsZVRJOC0WyikXd0pEsb/9cLniuE4atbsMqmFkw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.1.10':
+    resolution: {integrity: sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.5':
+    resolution: {integrity: sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/type@4.0.5':
+    resolution: {integrity: sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mswjs/interceptors@0.41.9':
+    resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
+    engines: {node: '>=18'}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/deferred-promise@3.0.0':
+    resolution: {integrity: sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@parcel/watcher-android-arm64@2.5.6':
+    resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    resolution: {integrity: sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    resolution: {integrity: sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    resolution: {integrity: sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    resolution: {integrity: sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    resolution: {integrity: sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    resolution: {integrity: sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@parcel/watcher@2.5.6':
+    resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
+    engines: {node: '>= 10.0.0'}
+
+  '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
+    resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0':
+    resolution: {integrity: sha512-BcCkm/STipKvbCl6b7QFrMh/vx00vIP63k2eM66MfHJzPr6O2U0jYEViXkHJWqXqQYjdeA9cuCl5KWmlwjDvbA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0':
+    resolution: {integrity: sha512-5BcGCBfBxB5+XSDSWnhTThfI9jcO5f0Ai2V24gZpG+wXF14BzwxxdDb4g6trdOux0rhibGs385BeFMSmxtS3uA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0':
+    resolution: {integrity: sha512-KVQ+PtIjb1BuYT3ht8M5KbzWBhdAjjUPdlMtpuw/VjT8coTrItWX6Qafl9+ji831JaJcu6PJNKCV0bp01lBNzQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-plugin-svg-dynamic-title@8.0.0':
+    resolution: {integrity: sha512-omNiKqwjNmOQJ2v6ge4SErBbkooV2aAWwaPFs2vUY7p7GhVkzRkJ00kILXQvRhA6miHnNpXv7MRnnSjdRjK8og==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-plugin-svg-em-dimensions@8.0.0':
+    resolution: {integrity: sha512-mURHYnu6Iw3UBTbhGwE/vsngtCIbHE43xCRK7kCw4t01xyGqb2Pd+WXekRRoFOBIY29ZoOhUCTEweDMdrjfi9g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-plugin-transform-react-native-svg@8.1.0':
+    resolution: {integrity: sha512-Tx8T58CHo+7nwJ+EhUwx3LfdNSG9R2OKfaIXXs5soiy5HtgoAEkDay9LIimLOcG8dJQH1wPZp/cnAv6S9CrR1Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-plugin-transform-svg-component@8.0.0':
+    resolution: {integrity: sha512-DFx8xa3cZXTdb/k3kfPeaixecQLgKh5NVBMwD0AQxOzcZawK4oo1Jh9LbrcACUivsCA7TLG8eeWgrDXjTMhRmw==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/babel-preset@8.1.0':
+    resolution: {integrity: sha512-7EYDbHE7MxHpv4sxvnVPngw5fuR6pw79SkcrILHJ/iMpuKySNCl5W1qcwPEpU+LgyRXOaAFgH0KhwD18wwg6ug==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@svgr/core@8.1.0':
+    resolution: {integrity: sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==}
+    engines: {node: '>=14'}
+
+  '@svgr/hast-util-to-babel-ast@8.0.0':
+    resolution: {integrity: sha512-EbDKwO9GpfWP4jN9sGdYwPBU0kdomaPIL2Eu4YwmgP+sJeXT+L7bMwJUBnhzfH8Q2qMBqZ4fJwpCyYsAN3mt2Q==}
+    engines: {node: '>=14'}
+
+  '@svgr/plugin-jsx@8.1.0':
+    resolution: {integrity: sha512-0xiIyBsLlr8quN+WyuxooNW9RJ0Dpr8uOnH/xrCVO8GLUcwHISwj1AG0k+LFzteTkAA0GbX0kj9q6Dk70PTiPA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@svgr/core': '*'
+
+  '@tailwindcss/node@4.3.0':
+    resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.0':
+    resolution: {integrity: sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.0':
+    resolution: {integrity: sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.0':
+    resolution: {integrity: sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.0':
+    resolution: {integrity: sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
+    resolution: {integrity: sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
+    resolution: {integrity: sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
+    resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
+    resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
+    resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
+    resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
+    resolution: {integrity: sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
+    resolution: {integrity: sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.0':
+    resolution: {integrity: sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/postcss@4.3.0':
+    resolution: {integrity: sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==}
+
+  '@tanstack/query-core@5.100.10':
+    resolution: {integrity: sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w==}
+
+  '@tanstack/react-query@5.100.10':
+    resolution: {integrity: sha512-FLaZf2RCrA/Zgp4aiu5tG3TyasTRO7aZ99skxQpr3Hg/zXOhu6yq5FZCYQ/tRaJtM9ylnoK8tFK7PolXQadv6Q==}
+    peerDependencies:
+      react: ^18 || ^19
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/node@25.9.0':
+    resolution: {integrity: sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/set-cookie-parser@2.4.10':
+    resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
+
+  '@types/statuses@2.0.6':
+    resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
+  '@xyflow/react@12.10.2':
+    resolution: {integrity: sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@xyflow/system@0.0.76':
+    resolution: {integrity: sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  autoprefixer@10.5.0:
+    resolution: {integrity: sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  baseline-browser-mapping@2.10.30:
+    resolution: {integrity: sha512-xjOFN16Ha1+Rz4nFYKqHU/LSB+gx/Vi3yQLX7r7sAW+Wa+8hhF2h4pvqTrTMc8+WcDBEunnUurr46Jvv0jk3Vg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
+  caniuse-lite@1.0.30001793:
+    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
+  cosmiconfig@8.3.6:
+    resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  cuint@0.2.2:
+    resolution: {integrity: sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw==}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  dot-case@3.0.4:
+    resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
+
+  electron-to-chromium@1.5.358:
+    resolution: {integrity: sha512-EO7tKm3QxRqTs1lSuPXzl6yRAwznehp0AH9OoMOIC+4mQzTFday8FJCO5KU6J/TFSQXEOahNq4vTKpz1jmCVOA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  enhanced-resolve@5.21.3:
+    resolution: {integrity: sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==}
+    engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.0:
+    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
+
+  fraction.js@5.3.4:
+    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  graphql@16.14.0:
+    resolution: {integrity: sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
+  headers-polyfill@5.0.1:
+    resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
+
+  immutable@5.1.5:
+    resolution: {integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  lower-case@2.0.2:
+    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  make-dir@3.1.0:
+    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
+    engines: {node: '>=8'}
+
+  mime@2.5.2:
+    resolution: {integrity: sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  msw@2.14.6:
+    resolution: {integrity: sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  no-case@3.0.4:
+    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-releases@2.0.44:
+    resolution: {integrity: sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==}
+
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss-url@10.1.3:
+    resolution: {integrity: sha512-FUzyxfI5l2tKmXdYc6VTu3TWZsInayEKPbiyW+P6vmmIrrb4I6CGX0BFoewgYHLK+oIL5FECEK02REYRpBvUCw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      postcss: ^8.0.0
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  react-dom@19.2.6:
+    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
+    peerDependencies:
+      react: ^19.2.6
+
+  react-router@7.15.1:
+    resolution: {integrity: sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
+  react@19.2.6:
+    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+    engines: {node: '>=0.10.0'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  rettime@0.11.11:
+    resolution: {integrity: sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==}
+
+  sass@1.99.0:
+    resolution: {integrity: sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  set-cookie-parser@3.1.0:
+    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  snake-case@3.0.4:
+    resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  svg-parser@2.0.4:
+    resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
+
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
+  tailwindcss@4.3.0:
+    resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
+  tldts-core@7.0.30:
+    resolution: {integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==}
+
+  tldts@7.0.30:
+    resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
+    hasBin: true
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  until-async@3.0.2:
+    resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  xxhashjs@0.2.2:
+    resolution: {integrity: sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+
+  zustand@5.0.13:
+    resolution: {integrity: sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
+snapshots:
+
+  '@alloc/quick-lru@5.2.0': {}
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.3': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.3
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@cloudoperators/juno-ui-components@6.4.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
+    optional: true
+
+  '@inquirer/ansi@2.0.5': {}
+
+  '@inquirer/confirm@6.0.13(@types/node@25.9.0)':
+    dependencies:
+      '@inquirer/core': 11.1.10(@types/node@25.9.0)
+      '@inquirer/type': 4.0.5(@types/node@25.9.0)
+    optionalDependencies:
+      '@types/node': 25.9.0
+
+  '@inquirer/core@11.1.10(@types/node@25.9.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@25.9.0)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.0
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 25.9.0
+
+  '@inquirer/figures@2.0.5': {}
+
+  '@inquirer/type@4.0.5(@types/node@25.9.0)':
+    optionalDependencies:
+      '@types/node': 25.9.0
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mswjs/interceptors@0.41.9':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/deferred-promise@3.0.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
+
+  '@parcel/watcher-android-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher@2.5.6':
+    dependencies:
+      detect-libc: 2.1.2
+      is-glob: 4.0.3
+      node-addon-api: 7.1.1
+      picomatch: 4.0.4
+    optionalDependencies:
+      '@parcel/watcher-android-arm64': 2.5.6
+      '@parcel/watcher-darwin-arm64': 2.5.6
+      '@parcel/watcher-darwin-x64': 2.5.6
+      '@parcel/watcher-freebsd-x64': 2.5.6
+      '@parcel/watcher-linux-arm-glibc': 2.5.6
+      '@parcel/watcher-linux-arm-musl': 2.5.6
+      '@parcel/watcher-linux-arm64-glibc': 2.5.6
+      '@parcel/watcher-linux-arm64-musl': 2.5.6
+      '@parcel/watcher-linux-x64-glibc': 2.5.6
+      '@parcel/watcher-linux-x64-musl': 2.5.6
+      '@parcel/watcher-win32-arm64': 2.5.6
+      '@parcel/watcher-win32-ia32': 2.5.6
+      '@parcel/watcher-win32-x64': 2.5.6
+    optional: true
+
+  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+
+  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+
+  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+
+  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+
+  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+
+  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+
+  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+
+  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+
+  '@svgr/babel-preset@8.1.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0)
+
+  '@svgr/core@8.1.0(typescript@6.0.3)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
+      camelcase: 6.3.0
+      cosmiconfig: 8.3.6(typescript@6.0.3)
+      snake-case: 3.0.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@svgr/hast-util-to-babel-ast@8.0.0':
+    dependencies:
+      '@babel/types': 7.29.0
+      entities: 4.5.0
+
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@6.0.3))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
+      '@svgr/core': 8.1.0(typescript@6.0.3)
+      '@svgr/hast-util-to-babel-ast': 8.0.0
+      svg-parser: 2.0.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tailwindcss/node@4.3.0':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.21.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.0
+
+  '@tailwindcss/oxide-android-arm64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.0':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.0
+      '@tailwindcss/oxide-darwin-arm64': 4.3.0
+      '@tailwindcss/oxide-darwin-x64': 4.3.0
+      '@tailwindcss/oxide-freebsd-x64': 4.3.0
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.0
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.0
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.0
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
+
+  '@tailwindcss/postcss@4.3.0':
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      '@tailwindcss/node': 4.3.0
+      '@tailwindcss/oxide': 4.3.0
+      postcss: 8.5.14
+      tailwindcss: 4.3.0
+
+  '@tanstack/query-core@5.100.10': {}
+
+  '@tanstack/react-query@5.100.10(react@19.2.6)':
+    dependencies:
+      '@tanstack/query-core': 5.100.10
+      react: 19.2.6
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/node@25.9.0':
+    dependencies:
+      undici-types: 7.24.6
+
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
+  '@types/set-cookie-parser@2.4.10':
+    dependencies:
+      '@types/node': 25.9.0
+
+  '@types/statuses@2.0.6': {}
+
+  '@xyflow/react@12.10.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@xyflow/system': 0.0.76
+      classcat: 5.0.5
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      zustand: 4.5.7(@types/react@19.2.14)(react@19.2.6)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@xyflow/system@0.0.76':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  argparse@2.0.1: {}
+
+  autoprefixer@10.5.0(postcss@8.5.14):
+    dependencies:
+      browserslist: 4.28.2
+      caniuse-lite: 1.0.30001793
+      fraction.js: 5.3.4
+      picocolors: 1.1.1
+      postcss: 8.5.14
+      postcss-value-parser: 4.2.0
+
+  balanced-match@1.0.2: {}
+
+  baseline-browser-mapping@2.10.30: {}
+
+  brace-expansion@1.1.14:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.30
+      caniuse-lite: 1.0.30001793
+      electron-to-chromium: 1.5.358
+      node-releases: 2.0.44
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  callsites@3.1.0: {}
+
+  camelcase@6.3.0: {}
+
+  caniuse-lite@1.0.30001793: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  classcat@5.0.5: {}
+
+  cli-width@4.1.0: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  concat-map@0.0.1: {}
+
+  convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
+
+  cosmiconfig@8.3.6(typescript@6.0.3):
+    dependencies:
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+      path-type: 4.0.0
+    optionalDependencies:
+      typescript: 6.0.3
+
+  csstype@3.2.3: {}
+
+  cuint@0.2.2: {}
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  detect-libc@2.1.2: {}
+
+  dot-case@3.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.8.1
+
+  electron-to-chromium@1.5.358: {}
+
+  emoji-regex@8.0.0: {}
+
+  enhanced-resolve@5.21.3:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
+  entities@4.5.0: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
+  escalade@3.2.0: {}
+
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
+
+  fraction.js@5.3.4: {}
+
+  gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
+
+  graceful-fs@4.2.11: {}
+
+  graphql@16.14.0: {}
+
+  headers-polyfill@5.0.1:
+    dependencies:
+      '@types/set-cookie-parser': 2.4.10
+      set-cookie-parser: 3.1.0
+
+  immutable@5.1.5: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  is-arrayish@0.2.1: {}
+
+  is-extglob@2.1.1:
+    optional: true
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+    optional: true
+
+  is-node-process@1.2.0: {}
+
+  jiti@2.7.0: {}
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  jsesc@3.1.0: {}
+
+  json-parse-even-better-errors@2.3.1: {}
+
+  json5@2.2.3: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  lines-and-columns@1.2.4: {}
+
+  lower-case@2.0.2:
+    dependencies:
+      tslib: 2.8.1
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  make-dir@3.1.0:
+    dependencies:
+      semver: 6.3.1
+
+  mime@2.5.2: {}
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.14
+
+  ms@2.1.3: {}
+
+  msw@2.14.6(@types/node@25.9.0)(typescript@6.0.3):
+    dependencies:
+      '@inquirer/confirm': 6.0.13(@types/node@25.9.0)
+      '@mswjs/interceptors': 0.41.9
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.14.0
+      headers-polyfill: 5.0.1
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.11
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.6.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  mute-stream@3.0.0: {}
+
+  nanoid@3.3.12: {}
+
+  no-case@3.0.4:
+    dependencies:
+      lower-case: 2.0.2
+      tslib: 2.8.1
+
+  node-addon-api@7.1.1:
+    optional: true
+
+  node-releases@2.0.44: {}
+
+  outvariant@1.4.3: {}
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
+  path-to-regexp@6.3.0: {}
+
+  path-type@4.0.0: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4:
+    optional: true
+
+  postcss-url@10.1.3(postcss@8.5.14):
+    dependencies:
+      make-dir: 3.1.0
+      mime: 2.5.2
+      minimatch: 3.1.5
+      postcss: 8.5.14
+      xxhashjs: 0.2.2
+
+  postcss-value-parser@4.2.0: {}
+
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  prettier@3.8.3: {}
+
+  react-dom@19.2.6(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      scheduler: 0.27.0
+
+  react-router@7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.6
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.6(react@19.2.6)
+
+  react@19.2.6: {}
+
+  readdirp@4.1.2: {}
+
+  require-directory@2.1.1: {}
+
+  resolve-from@4.0.0: {}
+
+  rettime@0.11.11: {}
+
+  sass@1.99.0:
+    dependencies:
+      chokidar: 4.0.3
+      immutable: 5.1.5
+      source-map-js: 1.2.1
+    optionalDependencies:
+      '@parcel/watcher': 2.5.6
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  set-cookie-parser@2.7.2: {}
+
+  set-cookie-parser@3.1.0: {}
+
+  signal-exit@4.1.0: {}
+
+  snake-case@3.0.4:
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.8.1
+
+  source-map-js@1.2.1: {}
+
+  statuses@2.0.2: {}
+
+  strict-event-emitter@0.5.1: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  svg-parser@2.0.4: {}
+
+  tagged-tag@1.0.0: {}
+
+  tailwindcss@4.3.0: {}
+
+  tapable@2.3.3: {}
+
+  tldts-core@7.0.30: {}
+
+  tldts@7.0.30:
+    dependencies:
+      tldts-core: 7.0.30
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.30
+
+  tslib@2.8.1: {}
+
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
+
+  typescript@6.0.3: {}
+
+  undici-types@7.24.6: {}
+
+  until-async@3.0.2: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  use-sync-external-store@1.6.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  xxhashjs@0.2.2:
+    dependencies:
+      cuint: 0.2.2
+
+  y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  zustand@4.5.7(@types/react@19.2.14)(react@19.2.6):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.6
+
+  zustand@5.0.13(@types/react@19.2.14)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6)):
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.6
+      use-sync-external-store: 1.6.0(react@19.2.6)

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
+  msw: true
+minimumReleaseAgeExclude:
+  - minimatch@3.1.4
+overrides:
+  minimatch@<3.1.4: ^3.1.4

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="favicon.ico" sizes="any" />
+    <title>ArcherUI Dev</title>
+    <style>
+      html {
+        display: flex;
+        flex-direction: column;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        flex-grow: 1;
+        height: 100vh;
+        margin: 0;
+        padding: 0;
+      }
+      #root {
+        display: block;
+        width: 1140px;
+        margin: auto;
+      }
+    </style>
+    <script>
+      // Automatically reload on build changes
+      new EventSource("/esbuild").addEventListener("change", () => location.reload());
+    </script>
+  </head>
+  <body>
+    <script type="module">
+      const defaultProps = "./build/appProps.json";
+
+      fetch(defaultProps)
+        .then((res) => res.json())
+        .catch((error) => {
+          console.warn("Failed to get appProps.json", error.message);
+          return { mockAPI: true };
+        })
+        .then((props) => {
+          props.getTokenFuncName = "_getCurrentToken";
+          window._getCurrentToken = async () => {
+            return { authToken: props.token };
+          };
+          import("./build/index.js").then((app) => {
+            app.mount(document.getElementById("root"), { props: props });
+          });
+        });
+    </script>
+    <div id="root" data-juno-app="archerUI"></div>
+  </body>
+</html>

--- a/web/public/mockServiceWorker.js
+++ b/web/public/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.14.6'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useState } from "react";
+import {
+  AppShell,
+  AppShellProvider,
+  Message,
+  LoadingIndicator,
+  PageHeader,
+  Stack,
+  Icon,
+  Badge,
+  ThemeToggle,
+} from "@cloudoperators/juno-ui-components";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useStore } from "./store";
+import { AppRoutes } from "./Routes";
+import { useVersion } from "./api";
+import { NotificationBell } from "./components/NotificationBell";
+import type { AppProps } from "./types";
+// @ts-expect-error css import
+import styles from "./styles.css";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { staleTime: 5 * 60 * 1000, retry: 1 },
+  },
+});
+
+const HeaderContent = () => {
+  const { data: version } = useVersion();
+  const { archerctlUrl, docsUrl } = useStore((s) => s.globalAPI);
+
+  return (
+    <Stack gap="4" alignment="center">
+      {docsUrl && (
+        <a
+          href={docsUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-white hover:text-theme-accent flex items-center gap-1"
+        >
+          <Icon icon="openInNew" size="18" />
+          <span>API</span>
+        </a>
+      )}
+      {archerctlUrl && (
+        <a
+          href={archerctlUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-white hover:text-theme-accent flex items-center gap-1"
+        >
+          <Icon icon="download" size="18" />
+          <span>CLI</span>
+        </a>
+      )}
+      {version && <Badge icon={false} text={version.version} />}
+      <NotificationBell />
+      <ThemeToggle />
+    </Stack>
+  );
+};
+
+const AppContent = ({
+  canEdit,
+  embedded,
+  cloudAdmin,
+}: {
+  canEdit: boolean;
+  embedded: boolean;
+  cloudAdmin: boolean;
+}) => {
+  const apiReady = useStore((s) => s.globalAPI.apiReady);
+
+  if (!apiReady) return <LoadingIndicator className="m-auto" />;
+  return <AppRoutes canEdit={canEdit} embedded={embedded} cloudAdmin={cloudAdmin} />;
+};
+
+const App = (props: AppProps) => {
+  const setGlobalAPI = useStore((s) => s.setGlobalAPI);
+  const setToken = useStore((s) => s.setToken);
+  const setApiReady = useStore((s) => s.setApiReady);
+  const [tokenError, setTokenError] = useState(false);
+
+  const canEdit = props.canEdit === true || props.canEdit === "true";
+  const embedded = props.embedded === true || props.embedded === "true";
+  const cloudAdmin = props.cloudAdmin === true || props.cloudAdmin === "true";
+
+  useEffect(() => {
+    setGlobalAPI({
+      endpoint: props.endpoint || "",
+      projectID: props.projectID || "",
+      archerctlUrl: props.archerctlUrl || "https://github.com/sapcc/archer/releases/latest",
+      docsUrl: props.docsUrl || "https://sapcc.github.io/archer/",
+      theme: (props.theme as "theme-dark" | "theme-light") || "theme-dark",
+      neutronEndpoint: props.neutronEndpoint || "",
+      cloudAdmin,
+    });
+  }, [
+    props.endpoint,
+    props.projectID,
+    props.archerctlUrl,
+    props.docsUrl,
+    props.theme,
+    props.neutronEndpoint,
+    cloudAdmin,
+    setGlobalAPI,
+  ]);
+
+  useEffect(() => {
+    const fetchToken = async () => {
+      const name = props.getTokenFuncName;
+      const fn = name ? (window as unknown as Record<string, unknown>)[name] : undefined;
+      if (typeof fn === "function") {
+        const result = await (fn as () => Promise<{ authToken: string }>)();
+        setToken(result.authToken);
+        setApiReady(true);
+      } else if (props.token) {
+        setToken(props.token);
+        setApiReady(true);
+      } else {
+        setTokenError(true);
+      }
+    };
+    fetchToken();
+  }, [props.getTokenFuncName, props.token, setToken, setApiReady]);
+
+  if (tokenError) {
+    return <Message>No token provided.</Message>;
+  }
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AppShell
+        pageHeader={
+          <PageHeader applicationName="Archer - Endpoint as a Service">
+            <HeaderContent />
+          </PageHeader>
+        }
+        embedded={embedded}
+      >
+        <AppContent canEdit={canEdit} embedded={embedded} cloudAdmin={cloudAdmin} />
+      </AppShell>
+    </QueryClientProvider>
+  );
+};
+
+export const StyledApp = (props: AppProps) => (
+  <AppShellProvider theme={(props.theme as "theme-dark" | "theme-light") || "theme-dark"}>
+    <style>{styles.toString()}</style>
+    <App {...props} />
+  </AppShellProvider>
+);
+
+export default StyledApp;

--- a/web/src/Routes.tsx
+++ b/web/src/Routes.tsx
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { lazy, Suspense } from "react";
+import {
+  Container,
+  TabNavigation,
+  TabNavigationItem,
+  Stack,
+  Icon,
+  Badge,
+  LoadingIndicator,
+} from "@cloudoperators/juno-ui-components";
+import { HashRouter, Routes, Route, Navigate, useLocation, useNavigate, Outlet } from "react-router";
+import { ServiceList } from "./components/ServiceList";
+import { EndpointList } from "./components/EndpointList";
+import { RBACList } from "./components/RBACList";
+import { AgentList } from "./components/AgentList";
+import { useVersion } from "./api";
+import { useStore } from "./store";
+
+const NetworkGraph = lazy(() => import("./components/NetworkGraph").then((m) => ({ default: m.NetworkGraph })));
+
+const Nav = ({ embedded, cloudAdmin }: { embedded: boolean; cloudAdmin: boolean }) => {
+  const loc = useLocation();
+  const nav = useNavigate();
+  const tab = loc.pathname.split("/")[1] || "endpoints";
+  const { data: version } = useVersion();
+  const { archerctlUrl, docsUrl } = useStore((s) => s.globalAPI);
+
+  return (
+    <Stack distribution="between" alignment="center">
+      <TabNavigation activeItem={tab}>
+        <TabNavigationItem label="Endpoints" value="endpoints" onClick={() => nav("/endpoints")} icon="place" />
+        <TabNavigationItem label="Services" value="services" onClick={() => nav("/services")} icon="widgets" />
+        <TabNavigationItem label="RBAC" value="rbac" onClick={() => nav("/rbac")} icon="manageAccounts" />
+        <TabNavigationItem label="Topology" value="topology" onClick={() => nav("/topology")} icon="dns" />
+        {cloudAdmin && (
+          <TabNavigationItem
+            label="Agents"
+            value="agents"
+            onClick={() => nav("/agents")}
+            icon="autoAwesomeMotion"
+            className="text-theme-danger"
+          />
+        )}
+      </TabNavigation>
+      {embedded && (
+        <Stack gap="4" alignment="center">
+          {docsUrl && (
+            <a
+              href={docsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-theme-accent hover:underline flex items-center gap-1"
+            >
+              <Icon icon="openInNew" size="18" />
+              <span>API</span>
+            </a>
+          )}
+          {archerctlUrl && (
+            <a
+              href={archerctlUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-theme-accent hover:underline flex items-center gap-1"
+            >
+              <Icon icon="download" size="18" />
+              <span>CLI</span>
+            </a>
+          )}
+          {version && <Badge icon={false} text={version.version} />}
+        </Stack>
+      )}
+    </Stack>
+  );
+};
+
+const Layout = ({ canEdit, embedded, cloudAdmin }: { canEdit: boolean; embedded: boolean; cloudAdmin: boolean }) => (
+  <div className="flex flex-col gap-4">
+    <Nav embedded={embedded} cloudAdmin={cloudAdmin} />
+    <Outlet context={{ canEdit }} />
+  </div>
+);
+
+export const AppRoutes = ({
+  canEdit,
+  embedded,
+  cloudAdmin,
+}: {
+  canEdit: boolean;
+  embedded: boolean;
+  cloudAdmin: boolean;
+}) => (
+  <Container px={false}>
+    <HashRouter>
+      <Routes>
+        <Route element={<Layout canEdit={canEdit} embedded={embedded} cloudAdmin={cloudAdmin} />}>
+          <Route index element={<Navigate to="/endpoints" replace />} />
+          <Route path="/services/*" element={<ServiceList canEdit={canEdit} cloudAdmin={cloudAdmin} />} />
+          <Route path="/endpoints/*" element={<EndpointList canEdit={canEdit} cloudAdmin={cloudAdmin} />} />
+          <Route path="/rbac/*" element={<RBACList canEdit={canEdit} />} />
+          <Route
+            path="/topology"
+            element={
+              <Suspense fallback={<LoadingIndicator className="m-auto" />}>
+                <NetworkGraph />
+              </Suspense>
+            }
+          />
+          {cloudAdmin && <Route path="/agents" element={<AgentList />} />}
+        </Route>
+      </Routes>
+    </HashRouter>
+  </Container>
+);

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,0 +1,476 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { useQuery, useQueries, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useStore } from "./store";
+import type {
+  Service,
+  ServiceCreate,
+  ServiceUpdate,
+  Endpoint,
+  EndpointCreate,
+  EndpointUpdate,
+  EndpointConsumer,
+  RBACPolicy,
+  RBACPolicyCreate,
+  RBACPolicyUpdate,
+  Agent,
+  ListResponse,
+  Version,
+  NetworksResponse,
+  SubnetsResponse,
+  PortsResponse,
+} from "./types";
+
+// Pending status helpers
+export const isPendingService = (s: Service): boolean =>
+  s.status === "PENDING_CREATE" || s.status === "PENDING_UPDATE" || s.status === "PENDING_DELETE";
+
+export const isPendingEndpoint = (e: { status: string }): boolean =>
+  e.status === "PENDING_APPROVAL" ||
+  e.status === "PENDING_CREATE" ||
+  e.status === "PENDING_UPDATE" ||
+  e.status === "PENDING_REJECTED" ||
+  e.status === "PENDING_DELETE";
+
+// Transient pending = states the backend will resolve on its own.
+// Excludes PENDING_APPROVAL and PENDING_REJECTED, which wait on human action and shouldn't drive polling.
+const isTransientPending = (e: { status: string }): boolean =>
+  e.status === "PENDING_CREATE" || e.status === "PENDING_UPDATE" || e.status === "PENDING_DELETE";
+
+// Backoff schedule for queries that poll while something is transitioning.
+// Avoids hammering when state stays pending longer than expected.
+const pollDelay = (failureCount: number, dataUpdateCount: number): number => {
+  // Use whichever counter is higher — covers both repeated failures and repeated pending observations.
+  const n = Math.max(failureCount, dataUpdateCount);
+  if (n < 5) return 3000;
+  if (n < 15) return 10000;
+  if (n < 30) return 30000;
+  return 60000;
+};
+
+const getHeaders = (token: string, withContent = false) => ({
+  Accept: "application/json",
+  "X-Auth-Token": token,
+  ...(withContent && { "Content-Type": "application/json" }),
+});
+
+async function fetchJson<T>(url: string, init: RequestInit): Promise<T | null> {
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    const text = await res.text();
+    let message = text;
+    try {
+      const json = JSON.parse(text);
+      message = json.message || JSON.stringify(json, null, 2);
+    } catch {
+      // Not JSON, use raw text
+    }
+    throw new Error(`${message} (${res.status})`);
+  }
+  if (res.status === 204 || res.status === 202) return null;
+  return res.json();
+}
+
+// For endpoints we know never return null on success (GETs, normal POSTs).
+async function fetchJsonRequired<T>(url: string, init: RequestInit): Promise<T> {
+  const result = await fetchJson<T>(url, init);
+  if (result === null) {
+    throw new Error(`Expected response body from ${url}, got 202/204`);
+  }
+  return result;
+}
+
+// Version
+export const useVersion = () => {
+  const { endpoint, token } = useStore((s) => s.globalAPI);
+  return useQuery({
+    queryKey: ["version"],
+    queryFn: () =>
+      fetchJsonRequired<Version>(`${endpoint}/`, {
+        headers: getHeaders(token),
+      }),
+    enabled: !!endpoint && !!token,
+  });
+};
+
+// Services
+export const useServices = () => {
+  const { endpoint, token } = useStore((s) => s.globalAPI);
+  return useQuery({
+    queryKey: ["services"],
+    queryFn: () =>
+      fetchJsonRequired<ListResponse<Service>>(`${endpoint}/service`, {
+        headers: getHeaders(token),
+      }),
+    enabled: !!endpoint && !!token,
+    refetchInterval: (query) => {
+      const items = query.state.data?.items ?? [];
+      if (!items.some(isPendingService)) return false;
+      return pollDelay(query.state.fetchFailureCount, query.state.dataUpdateCount);
+    },
+  });
+};
+
+export const useService = (id: string | undefined) => {
+  const { endpoint, token } = useStore((s) => s.globalAPI);
+  return useQuery({
+    queryKey: ["service", id],
+    queryFn: () =>
+      fetchJsonRequired<Service>(`${endpoint}/service/${id}`, {
+        headers: getHeaders(token),
+      }),
+    enabled: !!endpoint && !!token && !!id,
+    refetchInterval: (query) => {
+      const service = query.state.data;
+      if (!service || !isPendingService(service)) return false;
+      return pollDelay(query.state.fetchFailureCount, query.state.dataUpdateCount);
+    },
+  });
+};
+
+export const useServiceEndpoints = (serviceId: string | undefined) => {
+  const { endpoint, token } = useStore((s) => s.globalAPI);
+  return useQuery({
+    queryKey: ["serviceEndpoints", serviceId],
+    queryFn: () =>
+      fetchJsonRequired<ListResponse<EndpointConsumer>>(`${endpoint}/service/${serviceId}/endpoints`, {
+        headers: getHeaders(token),
+      }),
+    enabled: !!endpoint && !!token && !!serviceId,
+    refetchInterval: (query) => {
+      const items = query.state.data?.items ?? [];
+      if (!items.some(isTransientPending)) return false;
+      return pollDelay(query.state.fetchFailureCount, query.state.dataUpdateCount);
+    },
+  });
+};
+
+// Batch consumer fetch for N services. Polls per-service while any consumer is pending.
+export const useServiceConsumers = (serviceIds: string[]) => {
+  const { endpoint, token } = useStore((s) => s.globalAPI);
+  return useQueries({
+    queries: serviceIds.map((id) => ({
+      queryKey: ["serviceEndpoints", id],
+      queryFn: () =>
+        fetchJsonRequired<ListResponse<EndpointConsumer>>(`${endpoint}/service/${id}/endpoints`, {
+          headers: getHeaders(token),
+        }),
+      enabled: !!endpoint && !!token && !!id,
+      refetchInterval: (query: {
+        state: { data?: ListResponse<EndpointConsumer>; fetchFailureCount: number; dataUpdateCount: number };
+      }) => {
+        const items = query.state.data?.items ?? [];
+        if (!items.some(isTransientPending)) return false;
+        return pollDelay(query.state.fetchFailureCount, query.state.dataUpdateCount);
+      },
+    })),
+  });
+};
+
+export const useCreateService = () => {
+  const { endpoint, token } = useStore((s) => s.globalAPI);
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: ServiceCreate) =>
+      fetchJsonRequired<Service>(`${endpoint}/service`, {
+        method: "POST",
+        headers: getHeaders(token, true),
+        body: JSON.stringify(data),
+      }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["services"] }),
+  });
+};
+
+export const useUpdateService = () => {
+  const { endpoint, token } = useStore((s) => s.globalAPI);
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: ServiceUpdate }) =>
+      fetchJsonRequired<Service>(`${endpoint}/service/${id}`, {
+        method: "PUT",
+        headers: getHeaders(token, true),
+        body: JSON.stringify(data),
+      }),
+    onSuccess: (_, { id }) => {
+      qc.invalidateQueries({ queryKey: ["services"] });
+      qc.invalidateQueries({ queryKey: ["service", id] });
+    },
+  });
+};
+
+export const useDeleteService = () => {
+  const { endpoint, token } = useStore((s) => s.globalAPI);
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, cascade = false }: { id: string; cascade?: boolean }) =>
+      fetchJson<void>(`${endpoint}/service/${id}${cascade ? "?cascade=true" : ""}`, {
+        method: "DELETE",
+        headers: getHeaders(token),
+      }),
+    onSuccess: (_, { id }) => {
+      qc.invalidateQueries({ queryKey: ["services"] });
+      qc.removeQueries({ queryKey: ["service", id] });
+      qc.removeQueries({ queryKey: ["serviceEndpoints", id] });
+    },
+  });
+};
+
+export const useMigrateService = () => {
+  const { endpoint, token } = useStore((s) => s.globalAPI);
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, targetHost }: { id: string; targetHost?: string }) =>
+      fetchJsonRequired<Service>(`${endpoint}/service/${id}/migrate`, {
+        method: "POST",
+        headers: getHeaders(token, true),
+        body: JSON.stringify(targetHost ? { target_host: targetHost } : {}),
+      }),
+    onSuccess: (_, { id }) => {
+      qc.invalidateQueries({ queryKey: ["services"] });
+      qc.invalidateQueries({ queryKey: ["service", id] });
+    },
+  });
+};
+
+export const useAcceptEndpoints = () => {
+  const { endpoint, token } = useStore((s) => s.globalAPI);
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ serviceId, endpointIds }: { serviceId: string; endpointIds: string[] }) =>
+      fetchJsonRequired<EndpointConsumer[]>(`${endpoint}/service/${serviceId}/accept_endpoints`, {
+        method: "PUT",
+        headers: getHeaders(token, true),
+        body: JSON.stringify({ endpoint_ids: endpointIds }),
+      }),
+    onSuccess: (_, { serviceId }) => {
+      qc.invalidateQueries({ queryKey: ["serviceEndpoints", serviceId] });
+      qc.invalidateQueries({ queryKey: ["endpoints"] });
+    },
+  });
+};
+
+export const useRejectEndpoints = () => {
+  const { endpoint, token } = useStore((s) => s.globalAPI);
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ serviceId, endpointIds }: { serviceId: string; endpointIds: string[] }) =>
+      fetchJsonRequired<EndpointConsumer[]>(`${endpoint}/service/${serviceId}/reject_endpoints`, {
+        method: "PUT",
+        headers: getHeaders(token, true),
+        body: JSON.stringify({ endpoint_ids: endpointIds }),
+      }),
+    onSuccess: (_, { serviceId }) => {
+      qc.invalidateQueries({ queryKey: ["serviceEndpoints", serviceId] });
+      qc.invalidateQueries({ queryKey: ["endpoints"] });
+    },
+  });
+};
+
+// Endpoints
+export const useEndpoints = () => {
+  const { endpoint, token } = useStore((s) => s.globalAPI);
+  return useQuery({
+    queryKey: ["endpoints"],
+    queryFn: () =>
+      fetchJsonRequired<ListResponse<Endpoint>>(`${endpoint}/endpoint`, {
+        headers: getHeaders(token),
+      }),
+    enabled: !!endpoint && !!token,
+    refetchInterval: (query) => {
+      const items = query.state.data?.items ?? [];
+      if (!items.some(isTransientPending)) return false;
+      return pollDelay(query.state.fetchFailureCount, query.state.dataUpdateCount);
+    },
+  });
+};
+
+export const useEndpoint = (id: string | undefined) => {
+  const { endpoint, token } = useStore((s) => s.globalAPI);
+  return useQuery({
+    queryKey: ["endpoint", id],
+    queryFn: () =>
+      fetchJsonRequired<Endpoint>(`${endpoint}/endpoint/${id}`, {
+        headers: getHeaders(token),
+      }),
+    enabled: !!endpoint && !!token && !!id,
+    refetchInterval: (query) => {
+      const ep = query.state.data;
+      if (!ep || !isTransientPending(ep)) return false;
+      return pollDelay(query.state.fetchFailureCount, query.state.dataUpdateCount);
+    },
+  });
+};
+
+export const useCreateEndpoint = () => {
+  const { endpoint, token } = useStore((s) => s.globalAPI);
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: EndpointCreate) =>
+      fetchJsonRequired<Endpoint>(`${endpoint}/endpoint`, {
+        method: "POST",
+        headers: getHeaders(token, true),
+        body: JSON.stringify(data),
+      }),
+    onSuccess: (created) => {
+      qc.invalidateQueries({ queryKey: ["endpoints"] });
+      qc.invalidateQueries({ queryKey: ["serviceEndpoints", created.service_id] });
+    },
+  });
+};
+
+export const useUpdateEndpoint = () => {
+  const { endpoint, token } = useStore((s) => s.globalAPI);
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: EndpointUpdate }) =>
+      fetchJsonRequired<Endpoint>(`${endpoint}/endpoint/${id}`, {
+        method: "PUT",
+        headers: getHeaders(token, true),
+        body: JSON.stringify(data),
+      }),
+    onSuccess: (updated, { id }) => {
+      qc.invalidateQueries({ queryKey: ["endpoints"] });
+      qc.invalidateQueries({ queryKey: ["endpoint", id] });
+      qc.invalidateQueries({ queryKey: ["serviceEndpoints", updated.service_id] });
+    },
+  });
+};
+
+export const useDeleteEndpoint = () => {
+  const { endpoint, token } = useStore((s) => s.globalAPI);
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      fetchJson<void>(`${endpoint}/endpoint/${id}`, {
+        method: "DELETE",
+        headers: getHeaders(token),
+      }),
+    onSuccess: (_, id) => {
+      qc.invalidateQueries({ queryKey: ["endpoints"] });
+      qc.removeQueries({ queryKey: ["endpoint", id] });
+      // We don't know which service this endpoint belonged to once it's deleted,
+      // so invalidate all serviceEndpoints queries.
+      qc.invalidateQueries({ queryKey: ["serviceEndpoints"] });
+    },
+  });
+};
+
+// RBAC Policies
+export const useRBACPolicies = () => {
+  const { endpoint, token } = useStore((s) => s.globalAPI);
+  return useQuery({
+    queryKey: ["rbacPolicies"],
+    queryFn: () =>
+      fetchJsonRequired<ListResponse<RBACPolicy>>(`${endpoint}/rbac-policies`, {
+        headers: getHeaders(token),
+      }),
+    enabled: !!endpoint && !!token,
+  });
+};
+
+export const useCreateRBAC = () => {
+  const { endpoint, token } = useStore((s) => s.globalAPI);
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: RBACPolicyCreate) =>
+      fetchJsonRequired<RBACPolicy>(`${endpoint}/rbac-policies`, {
+        method: "POST",
+        headers: getHeaders(token, true),
+        body: JSON.stringify(data),
+      }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["rbacPolicies"] }),
+  });
+};
+
+export const useUpdateRBAC = () => {
+  const { endpoint, token } = useStore((s) => s.globalAPI);
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: RBACPolicyUpdate }) =>
+      fetchJsonRequired<RBACPolicy>(`${endpoint}/rbac-policies/${id}`, {
+        method: "PUT",
+        headers: getHeaders(token, true),
+        body: JSON.stringify(data),
+      }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["rbacPolicies"] }),
+  });
+};
+
+export const useDeleteRBAC = () => {
+  const { endpoint, token } = useStore((s) => s.globalAPI);
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      fetchJson<void>(`${endpoint}/rbac-policies/${id}`, {
+        method: "DELETE",
+        headers: getHeaders(token),
+      }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["rbacPolicies"] }),
+  });
+};
+
+// Agents (admin only)
+export const useAgents = () => {
+  const { endpoint, token } = useStore((s) => s.globalAPI);
+  return useQuery({
+    queryKey: ["agents"],
+    queryFn: () =>
+      fetchJsonRequired<ListResponse<Agent>>(`${endpoint}/agents`, {
+        headers: getHeaders(token),
+      }),
+    enabled: !!endpoint && !!token,
+  });
+};
+
+// Networks (from Neutron API)
+// In development, requests go through /proxy/neutron to bypass CORS
+export const useNetworks = (enabled: boolean) => {
+  const { neutronEndpoint, token } = useStore((s) => s.globalAPI);
+  const isDev = typeof window !== "undefined" && window.location.hostname === "localhost";
+  const baseUrl = isDev ? "/proxy/neutron" : neutronEndpoint;
+
+  return useQuery({
+    queryKey: ["networks"],
+    queryFn: () =>
+      fetchJsonRequired<NetworksResponse>(`${baseUrl}/v2.0/networks?limit=100`, {
+        headers: getHeaders(token),
+      }),
+    enabled: enabled && !!neutronEndpoint && !!token,
+    staleTime: 60 * 1000,
+  });
+};
+
+// Subnets (from Neutron API)
+export const useSubnets = (enabled: boolean) => {
+  const { neutronEndpoint, token } = useStore((s) => s.globalAPI);
+  const isDev = typeof window !== "undefined" && window.location.hostname === "localhost";
+  const baseUrl = isDev ? "/proxy/neutron" : neutronEndpoint;
+
+  return useQuery({
+    queryKey: ["subnets"],
+    queryFn: () =>
+      fetchJsonRequired<SubnetsResponse>(`${baseUrl}/v2.0/subnets?limit=100`, {
+        headers: getHeaders(token),
+      }),
+    enabled: enabled && !!neutronEndpoint && !!token,
+    staleTime: 60 * 1000,
+  });
+};
+
+// Ports (from Neutron API) - only unbound ports
+export const usePorts = (enabled: boolean) => {
+  const { neutronEndpoint, token } = useStore((s) => s.globalAPI);
+  const isDev = typeof window !== "undefined" && window.location.hostname === "localhost";
+  const baseUrl = isDev ? "/proxy/neutron" : neutronEndpoint;
+
+  return useQuery({
+    queryKey: ["ports"],
+    queryFn: () =>
+      fetchJsonRequired<PortsResponse>(`${baseUrl}/v2.0/ports?limit=100&device_owner=&device_id=`, {
+        headers: getHeaders(token),
+      }),
+    enabled: enabled && !!neutronEndpoint && !!token,
+    staleTime: 60 * 1000,
+  });
+};

--- a/web/src/components/AgentList.tsx
+++ b/web/src/components/AgentList.tsx
@@ -1,0 +1,290 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState, useMemo } from "react";
+import {
+  DataGrid,
+  DataGridRow,
+  DataGridCell,
+  DataGridHeadCell,
+  Stack,
+  LoadingIndicator,
+  Message,
+  Icon,
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TextInput,
+  Select,
+  SelectOption,
+  Button,
+} from "@cloudoperators/juno-ui-components";
+import { useAgents } from "../api";
+import type { Agent, Provider } from "../types";
+
+const ProviderLabel = ({ provider }: { provider: Provider | null }) => {
+  const isCP = provider === "cp";
+  return <span>{isCP ? "Control Plane" : "Tenant"}</span>;
+};
+
+const EnabledIcon = ({ enabled }: { enabled: boolean }) => (
+  <Tooltip>
+    <TooltipTrigger>
+      <Icon
+        icon={enabled ? "checkCircle" : "cancel"}
+        size="18"
+        className={enabled ? "text-green-500" : "text-red-500"}
+      />
+    </TooltipTrigger>
+    <TooltipContent>{enabled ? "Enabled" : "Disabled"}</TooltipContent>
+  </Tooltip>
+);
+
+const formatDate = (dateStr: string | null | undefined): string => {
+  if (!dateStr) return "-";
+  const date = new Date(dateStr);
+  return date.toLocaleString();
+};
+
+const HeartbeatStatus = ({ heartbeatAt }: { heartbeatAt: string | null | undefined }) => {
+  if (!heartbeatAt) return <span className="text-theme-light">-</span>;
+
+  const heartbeat = new Date(heartbeatAt);
+  const now = new Date();
+  const diffMs = now.getTime() - heartbeat.getTime();
+  const diffSeconds = diffMs / 1000;
+
+  const isRecent = diffSeconds < 30;
+  const isStale = diffSeconds >= 30 && diffSeconds < 5 * 60;
+  const isOld = diffSeconds >= 5 * 60;
+
+  const formatDiff = () => {
+    if (diffSeconds < 60) return `${Math.floor(diffSeconds)} sec ago`;
+    return `${Math.floor(diffSeconds / 60)} min ago`;
+  };
+
+  return (
+    <Tooltip>
+      <TooltipTrigger>
+        <Icon
+          icon={isRecent ? "checkCircle" : isOld ? "dangerous" : "warning"}
+          size="18"
+          className={isRecent ? "text-green-500" : isOld ? "text-red-500" : "text-yellow-500"}
+        />
+      </TooltipTrigger>
+      <TooltipContent>
+        Last heartbeat: {formatDate(heartbeatAt)}
+        {!isRecent && ` (${formatDiff()})`}
+      </TooltipContent>
+    </Tooltip>
+  );
+};
+
+type SortField = "host" | "availability_zone" | "provider" | "enabled" | "services";
+type SortDir = "asc" | "desc";
+
+const SortableHeader = ({
+  label,
+  field,
+  sortField,
+  sortDir,
+  onSort,
+}: {
+  label: string;
+  field: SortField;
+  sortField: SortField | null;
+  sortDir: SortDir;
+  onSort: (field: SortField) => void;
+}) => (
+  <DataGridHeadCell>
+    <button className="flex items-center gap-1 hover:text-theme-accent cursor-pointer" onClick={() => onSort(field)}>
+      {label}
+      {sortField === field && <Icon icon={sortDir === "asc" ? "expandLess" : "expandMore"} size="16" />}
+    </button>
+  </DataGridHeadCell>
+);
+
+export const AgentList = () => {
+  const { data, isLoading, error } = useAgents();
+
+  // Filter state
+  const [hostFilter, setHostFilter] = useState("");
+  const [providerFilter, setProviderFilter] = useState<string>("");
+  const [enabledFilter, setEnabledFilter] = useState<string>("");
+
+  // Sort state
+  const [sortField, setSortField] = useState<SortField | null>(null);
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+
+  const agents = data?.items ?? [];
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDir(sortDir === "asc" ? "desc" : "asc");
+    } else {
+      setSortField(field);
+      setSortDir("asc");
+    }
+  };
+
+  const filteredAndSortedAgents = useMemo(() => {
+    let result = agents.filter((a) => {
+      if (hostFilter && !a.host?.toLowerCase().includes(hostFilter.toLowerCase())) {
+        return false;
+      }
+      if (providerFilter && a.provider !== providerFilter) return false;
+      if (enabledFilter && (a.enabled ? "yes" : "no") !== enabledFilter) return false;
+      return true;
+    });
+
+    if (sortField) {
+      result = [...result].sort((a, b) => {
+        let aVal: string | boolean | number | null = "";
+        let bVal: string | boolean | number | null = "";
+
+        switch (sortField) {
+          case "host":
+            aVal = a.host || "";
+            bVal = b.host || "";
+            break;
+          case "availability_zone":
+            aVal = a.availability_zone || "";
+            bVal = b.availability_zone || "";
+            break;
+          case "provider":
+            aVal = a.provider || "";
+            bVal = b.provider || "";
+            break;
+          case "enabled":
+            aVal = a.enabled;
+            bVal = b.enabled;
+            break;
+          case "services":
+            aVal = a.services ?? 0;
+            bVal = b.services ?? 0;
+            break;
+        }
+
+        if (typeof aVal === "boolean") {
+          return sortDir === "asc" ? (aVal === bVal ? 0 : aVal ? -1 : 1) : aVal === bVal ? 0 : aVal ? 1 : -1;
+        }
+
+        if (typeof aVal === "number" && typeof bVal === "number") {
+          return sortDir === "asc" ? aVal - bVal : bVal - aVal;
+        }
+
+        const cmp = String(aVal || "").localeCompare(String(bVal || ""));
+        return sortDir === "asc" ? cmp : -cmp;
+      });
+    }
+
+    return result;
+  }, [agents, hostFilter, providerFilter, enabledFilter, sortField, sortDir]);
+
+  const clearFilters = () => {
+    setHostFilter("");
+    setProviderFilter("");
+    setEnabledFilter("");
+  };
+
+  const hasFilters = hostFilter || providerFilter || enabledFilter;
+
+  if (isLoading) return <LoadingIndicator className="m-auto" />;
+  if (error) return <Message variant="danger">{error.message}</Message>;
+
+  return (
+    <Stack direction="vertical" gap="4">
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: "1rem",
+          flexWrap: "wrap",
+        }}
+      >
+        <div style={{ display: "flex", flexDirection: "row", alignItems: "center", gap: "0.75rem", flexWrap: "wrap" }}>
+          <div style={{ width: "14rem" }}>
+            <TextInput
+              placeholder="Filter by host..."
+              value={hostFilter}
+              onChange={(e) => setHostFilter(e.target.value)}
+            />
+          </div>
+          <div style={{ width: "9rem" }}>
+            <Select value={providerFilter} onChange={(v) => setProviderFilter(String(v ?? ""))} placeholder="Provider">
+              <SelectOption value="tenant">Tenant</SelectOption>
+              <SelectOption value="cp">Control Plane</SelectOption>
+            </Select>
+          </div>
+          <div style={{ width: "8rem" }}>
+            <Select value={enabledFilter} onChange={(v) => setEnabledFilter(String(v ?? ""))} placeholder="Enabled">
+              <SelectOption value="yes">Yes</SelectOption>
+              <SelectOption value="no">No</SelectOption>
+            </Select>
+          </div>
+          {hasFilters && (
+            <Button variant="subdued" onClick={clearFilters}>
+              Clear Filters
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <DataGrid columns={7}>
+        <DataGridRow>
+          <SortableHeader label="Host" field="host" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
+          <SortableHeader
+            label="Availability Zone"
+            field="availability_zone"
+            sortField={sortField}
+            sortDir={sortDir}
+            onSort={handleSort}
+          />
+          <SortableHeader
+            label="Provider"
+            field="provider"
+            sortField={sortField}
+            sortDir={sortDir}
+            onSort={handleSort}
+          />
+          <DataGridHeadCell>Physnet</DataGridHeadCell>
+          <SortableHeader
+            label="Services"
+            field="services"
+            sortField={sortField}
+            sortDir={sortDir}
+            onSort={handleSort}
+          />
+          <DataGridHeadCell>Heartbeat</DataGridHeadCell>
+          <SortableHeader label="Enabled" field="enabled" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
+        </DataGridRow>
+        {filteredAndSortedAgents.map((a) => (
+          <DataGridRow key={a.host} className={!a.enabled ? "bg-theme-background-lvl-3 opacity-60" : ""}>
+            <DataGridCell>
+              <span className="font-semibold">{a.host}</span>
+            </DataGridCell>
+            <DataGridCell>{a.availability_zone || "-"}</DataGridCell>
+            <DataGridCell>
+              <ProviderLabel provider={a.provider} />
+            </DataGridCell>
+            <DataGridCell>{a.physnet || "-"}</DataGridCell>
+            <DataGridCell>{a.services ?? 0}</DataGridCell>
+            <DataGridCell>
+              <HeartbeatStatus heartbeatAt={a.heartbeat_at} />
+            </DataGridCell>
+            <DataGridCell>
+              <EnabledIcon enabled={a.enabled} />
+            </DataGridCell>
+          </DataGridRow>
+        ))}
+      </DataGrid>
+
+      {filteredAndSortedAgents.length === 0 && agents.length > 0 && (
+        <Message variant="info">No agents match your filters.</Message>
+      )}
+      {agents.length === 0 && <Message variant="info">No agents found.</Message>}
+    </Stack>
+  );
+};

--- a/web/src/components/DeleteModal.tsx
+++ b/web/src/components/DeleteModal.tsx
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { Modal, ModalFooter, Button, Stack, Message, Switch, Box } from "@cloudoperators/juno-ui-components";
+import { useStore } from "../store";
+
+interface Props {
+  onConfirm: (cascade?: boolean) => void;
+  isLoading?: boolean;
+  error?: Error | null;
+  cascade?: boolean;
+  onCascadeChange?: (cascade: boolean) => void;
+}
+
+export const DeleteModal = ({ onConfirm, isLoading, error, cascade, onCascadeChange }: Props) => {
+  const { deleteTarget, closeModals } = useStore();
+  if (!deleteTarget) return null;
+
+  const { type, item } = deleteTarget;
+  const name = "name" in item ? item.name : item.id;
+  const isService = type === "service";
+
+  return (
+    <Modal
+      title={`Delete ${type}`}
+      open
+      onCancel={closeModals}
+      modalFooter={
+        <ModalFooter className="justify-end gap-2">
+          <Button variant="subdued" onClick={closeModals} disabled={isLoading}>
+            Cancel
+          </Button>
+          <Button variant="primary-danger" icon="deleteForever" onClick={() => onConfirm(cascade)} disabled={isLoading}>
+            {isLoading ? "Deleting..." : "Delete"}
+          </Button>
+        </ModalFooter>
+      }
+    >
+      <Stack direction="vertical" gap="4">
+        <p>Are you sure you want to delete this {type}?</p>
+        <Box>
+          <strong>{name || item.id}</strong>
+          <br />
+          <span className="text-xs text-theme-light">{item.id}</span>
+        </Box>
+        {isService && onCascadeChange && (
+          <Switch
+            on={cascade}
+            onChange={(e) => onCascadeChange((e.target as HTMLButtonElement).getAttribute("aria-checked") === "true")}
+            label="Cascade"
+            helptext="Force delete all associated endpoints"
+          />
+        )}
+        {error && <Message variant="danger">{error.message}</Message>}
+      </Stack>
+    </Modal>
+  );
+};

--- a/web/src/components/EndpointDetail.tsx
+++ b/web/src/components/EndpointDetail.tsx
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  Panel,
+  PanelBody,
+  PanelFooter,
+  Button,
+  DataGrid,
+  DataGridRow,
+  DataGridCell,
+  LoadingIndicator,
+  Message,
+  Spinner,
+} from "@cloudoperators/juno-ui-components";
+import { useParams, useNavigate } from "react-router";
+import { useEndpoint, useService, isPendingEndpoint } from "../api";
+import { StatusBadge } from "./StatusBadge";
+
+export const EndpointDetail = () => {
+  const { endpointId } = useParams<{ endpointId: string }>();
+  const navigate = useNavigate();
+  const { data: ep, isLoading, error } = useEndpoint(endpointId);
+  const { data: service } = useService(ep?.service_id);
+
+  const close = () => navigate("/endpoints");
+  const fmt = (d: string | undefined) => (d ? new Date(d).toLocaleString() : "-");
+
+  const targetType = ep?.target.network ? "Network" : ep?.target.subnet ? "Subnet" : ep?.target.port ? "Port" : "-";
+  const targetValue = ep?.target.network || ep?.target.subnet || ep?.target.port || "-";
+
+  if (isLoading) {
+    return (
+      <Panel heading="Endpoint Details" opened onClose={close}>
+        <PanelBody>
+          <LoadingIndicator className="m-auto" />
+        </PanelBody>
+      </Panel>
+    );
+  }
+
+  if (error || !ep) {
+    return (
+      <Panel heading="Endpoint Details" opened onClose={close}>
+        <PanelBody>
+          <Message variant="danger">{error?.message || "Not found"}</Message>
+        </PanelBody>
+      </Panel>
+    );
+  }
+
+  const serviceLink = (
+    <div className="flex flex-col">
+      <button
+        type="button"
+        onClick={() => navigate(`/services/${ep.service_id}`)}
+        className="text-theme-accent hover:underline text-left cursor-pointer"
+      >
+        {service?.name || "Unnamed"}
+      </button>
+      <span className="text-xs text-theme-light">{ep.service_id}</span>
+    </div>
+  );
+
+  const panelHeading = (
+    <span className="flex items-center gap-2">
+      {ep.name || "Endpoint Details"}
+      {isPendingEndpoint(ep) && <Spinner size="small" />}
+    </span>
+  );
+
+  return (
+    <Panel heading={panelHeading} opened onClose={close}>
+      <PanelBody>
+        <DataGrid columns={2}>
+          {[
+            ["ID", ep.id],
+            ["Name", ep.name || "-"],
+            ["Description", ep.description || "-"],
+            ["Status", <StatusBadge key="s" status={ep.status} />],
+            ["Service", serviceLink],
+            ["IP Address", ep.ip_address || "-"],
+            ["Target Type", targetType],
+            ["Target ID", targetValue],
+            ["Tags", ep.tags?.join(", ") || "-"],
+            ["Project", ep.project_id],
+            ["Created", fmt(ep.created_at)],
+            ["Updated", fmt(ep.updated_at)],
+          ].map(([label, value], i) => (
+            <DataGridRow key={i}>
+              <DataGridCell className="font-semibold">{label}</DataGridCell>
+              <DataGridCell>{value}</DataGridCell>
+            </DataGridRow>
+          ))}
+        </DataGrid>
+      </PanelBody>
+      <PanelFooter>
+        <Button onClick={close}>Close</Button>
+      </PanelFooter>
+    </Panel>
+  );
+};

--- a/web/src/components/EndpointForm.tsx
+++ b/web/src/components/EndpointForm.tsx
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState, useEffect } from "react";
+import {
+  Modal,
+  TextInput,
+  Textarea,
+  Select,
+  SelectOption,
+  Stack,
+  FormRow,
+  Message,
+} from "@cloudoperators/juno-ui-components";
+import { useStore } from "../store";
+import { useCreateEndpoint, useUpdateEndpoint } from "../api";
+import { ServicePicker } from "./ServicePicker";
+import { NetworkPicker } from "./NetworkPicker";
+import { SubnetPicker } from "./SubnetPicker";
+import { PortPicker } from "./PortPicker";
+import type { EndpointCreate, EndpointUpdate, Service, Network, Subnet, Port } from "../types";
+
+type TargetType = "network" | "subnet" | "port";
+
+export const EndpointForm = () => {
+  const { editEndpoint, preselectedServiceId, closeModals } = useStore();
+  const isEdit = !!editEndpoint;
+  const create = useCreateEndpoint();
+  const update = useUpdateEndpoint();
+
+  const [form, setForm] = useState({
+    name: "",
+    description: "",
+    service_id: preselectedServiceId ?? "",
+    service_name: "",
+    target_type: "network" as TargetType,
+    target_value: "",
+    tags: "",
+  });
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (editEndpoint) {
+      const t = editEndpoint.target;
+      const type: TargetType = t.network ? "network" : t.subnet ? "subnet" : "port";
+      const value = t.network || t.subnet || t.port || "";
+      setForm({
+        name: editEndpoint.name ?? "",
+        description: editEndpoint.description ?? "",
+        service_id: editEndpoint.service_id,
+        service_name: "",
+        target_type: type,
+        target_value: value,
+        tags: editEndpoint.tags?.join(", ") ?? "",
+      });
+    }
+  }, [editEndpoint]);
+
+  const set = <K extends keyof typeof form>(k: K, v: (typeof form)[K]) => {
+    setForm((f) => ({ ...f, [k]: v }));
+    setError(null);
+  };
+
+  const handleServiceSelect = (service: Service) => {
+    set("service_id", service.id);
+    setForm((f) => ({ ...f, service_name: service.name || service.id }));
+  };
+
+  const handleTargetSelect = (item: Network | Subnet | Port) => {
+    set("target_value", item.id);
+  };
+
+  const neutronEndpoint = useStore((s) => s.globalAPI.neutronEndpoint);
+
+  const renderTargetPicker = () => {
+    if (!neutronEndpoint) return null;
+    switch (form.target_type) {
+      case "network":
+        return <NetworkPicker onSelect={handleTargetSelect} />;
+      case "subnet":
+        return <SubnetPicker onSelect={handleTargetSelect} />;
+      case "port":
+        return <PortPicker onSelect={handleTargetSelect} />;
+    }
+  };
+
+  const parseList = (s: string) =>
+    s
+      .split(",")
+      .map((x) => x.trim())
+      .filter(Boolean);
+
+  const submit = async () => {
+    if (!isEdit && !form.service_id) return setError("Service required");
+    if (!isEdit && !form.target_value.trim()) return setError("Target required");
+
+    try {
+      if (isEdit) {
+        const data: EndpointUpdate = {
+          name: form.name || null,
+          description: form.description || null,
+          tags: parseList(form.tags),
+        };
+        await update.mutateAsync({ id: editEndpoint!.id, data });
+      } else {
+        const data: EndpointCreate = {
+          service_id: form.service_id,
+          name: form.name || undefined,
+          description: form.description || undefined,
+          target: { [form.target_type]: form.target_value.trim() },
+          tags: parseList(form.tags),
+        };
+        await create.mutateAsync(data);
+      }
+      closeModals();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Unknown error");
+    }
+  };
+
+  const pending = create.isPending || update.isPending;
+
+  return (
+    <Modal
+      title={isEdit ? "Edit Endpoint" : "Create Endpoint"}
+      open
+      onCancel={closeModals}
+      onConfirm={submit}
+      confirmButtonLabel={pending ? "Saving..." : isEdit ? "Update" : "Create"}
+      confirmButtonIcon={isEdit ? "edit" : "addCircle"}
+      disableConfirmButton={pending}
+    >
+      <Stack direction="vertical" gap="4">
+        {error && <Message variant="danger">{error}</Message>}
+
+        <FormRow>
+          <TextInput label="Name" value={form.name} onChange={(e) => set("name", e.target.value)} />
+        </FormRow>
+        <FormRow>
+          <Textarea label="Description" value={form.description} onChange={(e) => set("description", e.target.value)} />
+        </FormRow>
+
+        {!isEdit && (
+          <>
+            <FormRow>
+              <div className="flex gap-2 items-end">
+                <div className="flex-1">
+                  <TextInput
+                    label="Service"
+                    value={form.service_name || form.service_id}
+                    onChange={(e) => {
+                      set("service_id", e.target.value);
+                      setForm((f) => ({ ...f, service_name: "" }));
+                    }}
+                    placeholder="Service ID"
+                    required
+                  />
+                </div>
+                <ServicePicker onSelect={handleServiceSelect} />
+              </div>
+            </FormRow>
+
+            <fieldset className="border border-theme-background-lvl-4 rounded p-4">
+              <legend className="px-2 text-sm font-semibold text-theme-light">Target Configuration</legend>
+              <Stack direction="vertical" gap="4">
+                <FormRow>
+                  <Select
+                    label="Target Type"
+                    value={form.target_type}
+                    onChange={(v) => {
+                      set("target_type", v as TargetType);
+                      set("target_value", "");
+                    }}
+                  >
+                    <SelectOption value="network">Network</SelectOption>
+                    <SelectOption value="subnet">Subnet</SelectOption>
+                    <SelectOption value="port">Port</SelectOption>
+                  </Select>
+                </FormRow>
+                <FormRow>
+                  <div className="flex gap-2 items-end">
+                    <div className="flex-1">
+                      <TextInput
+                        label="Target ID"
+                        value={form.target_value}
+                        onChange={(e) => set("target_value", e.target.value)}
+                        placeholder="UUID"
+                        required
+                      />
+                    </div>
+                    {renderTargetPicker()}
+                  </div>
+                </FormRow>
+              </Stack>
+            </fieldset>
+          </>
+        )}
+
+        <FormRow>
+          <TextInput
+            label="Tags"
+            value={form.tags}
+            onChange={(e) => set("tags", e.target.value)}
+            placeholder="production, team:network"
+            helptext="Comma-separated tags for organization"
+          />
+        </FormRow>
+
+        <p className="text-xs text-theme-light flex items-center gap-1">
+          <span className="w-2 h-2 rounded-full jn:bg-theme-required" />
+          Required fields
+        </p>
+      </Stack>
+    </Modal>
+  );
+};

--- a/web/src/components/EndpointList.tsx
+++ b/web/src/components/EndpointList.tsx
@@ -1,0 +1,530 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState, useMemo, useEffect, useRef } from "react";
+import {
+  DataGrid,
+  DataGridRow,
+  DataGridCell,
+  DataGridHeadCell,
+  Button,
+  Stack,
+  LoadingIndicator,
+  Message,
+  Icon,
+  TextInput,
+  Select,
+  SelectOption,
+  Badge,
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@cloudoperators/juno-ui-components";
+import { Routes, Route, useNavigate, useLocation } from "react-router";
+import {
+  useEndpoints,
+  useDeleteEndpoint,
+  useServices,
+  useServiceConsumers,
+  useAcceptEndpoints,
+  useRejectEndpoints,
+} from "../api";
+import { useStore } from "../store";
+import { useStatusChangeToast } from "../hooks/useStatusChangeToast";
+import { StatusBadge } from "./StatusBadge";
+import { DeleteModal } from "./DeleteModal";
+import { EndpointDetail } from "./EndpointDetail";
+import { EndpointForm } from "./EndpointForm";
+import type { Service, EndpointConsumer } from "../types";
+
+type PendingWithService = EndpointConsumer & { service: Service };
+
+type SortField = "name" | "status" | "ip_address" | "service_id";
+type SortDir = "asc" | "desc";
+
+const SortableHeader = ({
+  label,
+  field,
+  sortField,
+  sortDir,
+  onSort,
+}: {
+  label: string;
+  field: SortField;
+  sortField: SortField | null;
+  sortDir: SortDir;
+  onSort: (field: SortField) => void;
+}) => (
+  <DataGridHeadCell>
+    <button className="flex items-center gap-1 hover:text-theme-accent cursor-pointer" onClick={() => onSort(field)}>
+      {label}
+      {sortField === field && <Icon icon={sortDir === "asc" ? "expandLess" : "expandMore"} size="16" />}
+    </button>
+  </DataGridHeadCell>
+);
+
+export const EndpointList = ({ canEdit, cloudAdmin }: { canEdit: boolean; cloudAdmin: boolean }) => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { data, isLoading, error } = useEndpoints();
+  const { data: servicesData, isLoading: servicesLoading } = useServices();
+  const del = useDeleteEndpoint();
+  const accept = useAcceptEndpoints();
+  const reject = useRejectEndpoints();
+
+  const showEndpointModal = useStore((s) => s.showEndpointModal);
+  const showDeleteModal = useStore((s) => s.showDeleteModal);
+  const deleteTarget = useStore((s) => s.deleteTarget);
+  const openEndpointModal = useStore((s) => s.openEndpointModal);
+  const openDeleteModal = useStore((s) => s.openDeleteModal);
+  const closeModals = useStore((s) => s.closeModals);
+  const projectID = useStore((s) => s.globalAPI.projectID);
+  const addToast = useStore((s) => s.addToast);
+
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [pendingExpanded, setPendingExpanded] = useState(false);
+
+  // Create service name lookup and endpoint name lookup
+  const services = useMemo(() => servicesData?.items ?? [], [servicesData]);
+  const serviceNameMap = useMemo(() => {
+    const map = new Map<string, string>();
+    services.forEach((s) => {
+      map.set(s.id, s.name || "Unnamed");
+    });
+    return map;
+  }, [services]);
+
+  const endpoints = data?.items ?? [];
+  useStatusChangeToast(endpoints, "endpoint");
+  const endpointNameMap = useMemo(() => {
+    const map = new Map<string, string | null>();
+    endpoints.forEach((e) => map.set(e.id, e.name));
+    return map;
+  }, [endpoints]);
+
+  // Batch consumer fetches for all services (collapses N+1)
+  const serviceIds = useMemo(() => services.map((s) => s.id), [services]);
+  const consumerQueries = useServiceConsumers(serviceIds);
+
+  // Stable signature so dependent memos/effects don't fire on every render.
+  // useQueries returns a fresh array reference every render even when data is unchanged.
+  const consumersSignature = consumerQueries
+    .map((q) => (q.data?.items ?? []).map((c) => `${c.id}:${c.status}`).join(","))
+    .join("|");
+
+  const allPending = useMemo<PendingWithService[]>(() => {
+    const out: PendingWithService[] = [];
+    services.forEach((service, idx) => {
+      const items = consumerQueries[idx]?.data?.items ?? [];
+      for (const c of items) {
+        if (c.status === "PENDING_APPROVAL") {
+          out.push({ ...c, service });
+        }
+      }
+    });
+    return out;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [services, consumersSignature]);
+
+  // Track consumer status changes for toasts
+  const consumerStatusRef = useRef<Map<string, string>>(new Map());
+  useEffect(() => {
+    const tracked = consumerStatusRef.current;
+    services.forEach((_service, idx) => {
+      const items = consumerQueries[idx]?.data?.items ?? [];
+      for (const consumer of items) {
+        const prev = tracked.get(consumer.id);
+        const curr = consumer.status;
+        if (prev && prev !== curr) {
+          const name = endpointNameMap.get(consumer.id) || "Endpoint";
+          if (prev === "PENDING_APPROVAL" && curr === "AVAILABLE") {
+            addToast({ variant: "success", message: `${name} was accepted` });
+          } else if (prev === "PENDING_APPROVAL" && curr === "REJECTED") {
+            addToast({ variant: "warning", message: `${name} was rejected` });
+          } else if (curr === "FAILED") {
+            addToast({ variant: "danger", message: `${name} failed` });
+          }
+        }
+        tracked.set(consumer.id, curr);
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [services, consumersSignature, endpointNameMap, addToast]);
+
+  const handleRowClick = (id: string) => {
+    const currentPath = location.pathname;
+    if (currentPath === `/endpoints/${id}`) {
+      navigate("/endpoints");
+    } else {
+      navigate(`/endpoints/${id}`);
+    }
+  };
+
+  // Pending approval handlers
+  const handleAccept = async (serviceId: string, endpointIds: string[]) => {
+    try {
+      setActionError(null);
+      await accept.mutateAsync({ serviceId, endpointIds });
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : "Failed to accept");
+    }
+  };
+
+  const handleReject = async (serviceId: string, endpointIds: string[]) => {
+    try {
+      setActionError(null);
+      await reject.mutateAsync({ serviceId, endpointIds });
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : "Failed to reject");
+    }
+  };
+
+  const handleAcceptAll = async () => {
+    setActionError(null);
+    const byService = new Map<string, string[]>();
+    for (const p of allPending) {
+      const ids = byService.get(p.service.id) ?? [];
+      ids.push(p.id);
+      byService.set(p.service.id, ids);
+    }
+    try {
+      await Promise.all(
+        Array.from(byService, ([serviceId, endpointIds]) => accept.mutateAsync({ serviceId, endpointIds }))
+      );
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : "Failed to accept");
+    }
+  };
+
+  const handleRejectAll = async () => {
+    setActionError(null);
+    const byService = new Map<string, string[]>();
+    for (const p of allPending) {
+      const ids = byService.get(p.service.id) ?? [];
+      ids.push(p.id);
+      byService.set(p.service.id, ids);
+    }
+    try {
+      await Promise.all(
+        Array.from(byService, ([serviceId, endpointIds]) => reject.mutateAsync({ serviceId, endpointIds }))
+      );
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : "Failed to reject");
+    }
+  };
+
+  // Filter state
+  const [nameFilter, setNameFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState<string>("");
+
+  // Sort state
+  const [sortField, setSortField] = useState<SortField | null>(null);
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDir(sortDir === "asc" ? "desc" : "asc");
+    } else {
+      setSortField(field);
+      setSortDir("asc");
+    }
+  };
+
+  const filteredAndSortedEndpoints = useMemo(() => {
+    let result = endpoints.filter((e) => {
+      if (
+        nameFilter &&
+        !(
+          e.name?.toLowerCase().includes(nameFilter.toLowerCase()) ||
+          e.id.toLowerCase().includes(nameFilter.toLowerCase())
+        )
+      ) {
+        return false;
+      }
+      if (statusFilter && e.status !== statusFilter) return false;
+      return true;
+    });
+
+    if (sortField) {
+      result = [...result].sort((a, b) => {
+        const aVal = a[sortField] || "";
+        const bVal = b[sortField] || "";
+        const cmp = String(aVal).localeCompare(String(bVal));
+        return sortDir === "asc" ? cmp : -cmp;
+      });
+    }
+
+    return result;
+  }, [endpoints, nameFilter, statusFilter, sortField, sortDir]);
+
+  const handleDelete = async () => {
+    if (deleteTarget?.type === "endpoint") {
+      try {
+        await del.mutateAsync(deleteTarget.item.id);
+        closeModals();
+      } catch {
+        // Error is captured in del.error, displayed by DeleteModal
+      }
+    }
+  };
+
+  const clearFilters = () => {
+    setNameFilter("");
+    setStatusFilter("");
+  };
+
+  const hasFilters = nameFilter || statusFilter;
+
+  if (isLoading || servicesLoading) return <LoadingIndicator className="m-auto" />;
+  if (error) return <Message variant="danger">{error.message}</Message>;
+
+  return (
+    <>
+      <Stack direction="vertical" gap="4">
+        {/* Pending Approvals Section - shown at top when there are pending approvals */}
+        {allPending.length > 0 && (
+          <div className="bg-theme-background-lvl-2 p-4 rounded-lg">
+            <Stack direction="vertical" gap="4">
+              <div className="flex items-center justify-between">
+                <button
+                  className="flex items-center gap-2 cursor-pointer hover:opacity-80"
+                  onClick={() => setPendingExpanded(!pendingExpanded)}
+                >
+                  <Icon icon={pendingExpanded ? "expandMore" : "chevronRight"} size="24" />
+                  <Icon icon="accessTime" size="24" className="text-theme-warning" />
+                  <span className="font-semibold text-lg">Pending Approvals ({allPending.length})</span>
+                  <span className="text-theme-light text-sm">
+                    Endpoints from other projects requesting access to your services
+                  </span>
+                </button>
+                {canEdit && pendingExpanded && (
+                  <Stack gap="2">
+                    <Button size="small" onClick={handleAcceptAll} disabled={accept.isPending || reject.isPending}>
+                      Accept All
+                    </Button>
+                    <Button
+                      size="small"
+                      variant="primary-danger"
+                      onClick={handleRejectAll}
+                      disabled={accept.isPending || reject.isPending}
+                    >
+                      Reject All
+                    </Button>
+                  </Stack>
+                )}
+              </div>
+
+              {pendingExpanded && (
+                <>
+                  {actionError && <Message variant="danger">{actionError}</Message>}
+
+                  <DataGrid columns={canEdit ? 5 : 4}>
+                    <DataGridRow>
+                      <DataGridHeadCell>Service</DataGridHeadCell>
+                      <DataGridHeadCell>Endpoint</DataGridHeadCell>
+                      <DataGridHeadCell>Requesting Project</DataGridHeadCell>
+                      <DataGridHeadCell>Status</DataGridHeadCell>
+                      {canEdit && <DataGridHeadCell>Actions</DataGridHeadCell>}
+                    </DataGridRow>
+                    {allPending.map((p) => (
+                      <DataGridRow key={p.id}>
+                        <DataGridCell>
+                          <div className="flex flex-col">
+                            <span className="font-semibold">{p.service.name || "Unnamed"}</span>
+                            <span className="text-xs text-theme-light">{p.service.id}</span>
+                          </div>
+                        </DataGridCell>
+                        <DataGridCell>
+                          <div className="flex flex-col">
+                            <span className="font-semibold">{endpointNameMap.get(p.id) || "Unnamed"}</span>
+                            <span className="text-xs text-theme-light">{p.id}</span>
+                          </div>
+                        </DataGridCell>
+                        <DataGridCell>
+                          <span className="text-xs text-theme-light">{p.project_id}</span>
+                        </DataGridCell>
+                        <DataGridCell>
+                          <StatusBadge status={p.status} />
+                        </DataGridCell>
+                        {canEdit && (
+                          <DataGridCell>
+                            <Stack gap="1">
+                              <Button
+                                size="small"
+                                onClick={() => handleAccept(p.service.id, [p.id])}
+                                disabled={accept.isPending || reject.isPending}
+                              >
+                                Accept
+                              </Button>
+                              <Button
+                                size="small"
+                                variant="primary-danger"
+                                onClick={() => handleReject(p.service.id, [p.id])}
+                                disabled={accept.isPending || reject.isPending}
+                              >
+                                Reject
+                              </Button>
+                            </Stack>
+                          </DataGridCell>
+                        )}
+                      </DataGridRow>
+                    ))}
+                  </DataGrid>
+                </>
+              )}
+            </Stack>
+          </div>
+        )}
+
+        {/* Regular Endpoints Section */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: "1rem",
+            flexWrap: "wrap",
+          }}
+        >
+          <div
+            style={{ display: "flex", flexDirection: "row", alignItems: "center", gap: "0.75rem", flexWrap: "wrap" }}
+          >
+            <div style={{ width: "14rem" }}>
+              <TextInput
+                placeholder="Filter by name or ID..."
+                value={nameFilter}
+                onChange={(e) => setNameFilter(e.target.value)}
+              />
+            </div>
+            <div style={{ width: "10rem" }}>
+              <Select value={statusFilter} onChange={(v) => setStatusFilter(String(v ?? ""))} placeholder="Status">
+                <SelectOption value="AVAILABLE">Available</SelectOption>
+                <SelectOption value="PENDING_APPROVAL">Pending Approval</SelectOption>
+                <SelectOption value="PENDING_CREATE">Pending Create</SelectOption>
+                <SelectOption value="PENDING_UPDATE">Pending Update</SelectOption>
+                <SelectOption value="PENDING_DELETE">Pending Delete</SelectOption>
+                <SelectOption value="REJECTED">Rejected</SelectOption>
+                <SelectOption value="FAILED">Failed</SelectOption>
+              </Select>
+            </div>
+            {hasFilters && (
+              <Button variant="subdued" onClick={clearFilters}>
+                Clear Filters
+              </Button>
+            )}
+          </div>
+          {canEdit && !cloudAdmin && (
+            <Button icon="addCircle" onClick={() => openEndpointModal()}>
+              Create Endpoint
+            </Button>
+          )}
+        </div>
+
+        <DataGrid columns={canEdit ? 6 : 5}>
+          <DataGridRow>
+            <SortableHeader label="Name" field="name" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
+            <SortableHeader
+              label="Service"
+              field="service_id"
+              sortField={sortField}
+              sortDir={sortDir}
+              onSort={handleSort}
+            />
+            <SortableHeader label="Status" field="status" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
+            <SortableHeader label="IP" field="ip_address" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
+            <DataGridHeadCell>Tags</DataGridHeadCell>
+            {canEdit && <DataGridHeadCell>Actions</DataGridHeadCell>}
+          </DataGridRow>
+          {filteredAndSortedEndpoints.map((e) => {
+            const isExternal = projectID && e.project_id !== projectID;
+            return (
+              <DataGridRow
+                key={e.id}
+                onClick={() => handleRowClick(e.id)}
+                className={`cursor-pointer hover:bg-theme-background-lvl-2 ${isExternal ? "border-l-4 border-l-theme-warning" : ""}`}
+              >
+                <DataGridCell>
+                  <div className="flex flex-col max-w-72">
+                    <div className="flex items-center gap-1">
+                      <span className="font-semibold truncate" title={e.name || "Unnamed"}>
+                        {e.name || "Unnamed"}
+                      </span>
+                      {isExternal && (
+                        <Tooltip>
+                          <TooltipTrigger>
+                            <Icon icon="place" size="16" className="text-theme-warning" />
+                          </TooltipTrigger>
+                          <TooltipContent>External project: {e.project_id}</TooltipContent>
+                        </Tooltip>
+                      )}
+                    </div>
+                    <span className="text-xs text-theme-light">{e.id}</span>
+                  </div>
+                </DataGridCell>
+                <DataGridCell>
+                  <div className="flex flex-col max-w-48">
+                    <span className="font-semibold truncate" title={serviceNameMap.get(e.service_id) || "Unknown"}>
+                      {serviceNameMap.get(e.service_id) || "Unknown"}
+                    </span>
+                    <span className="text-xs text-theme-light">{e.service_id.slice(0, 8)}...</span>
+                  </div>
+                </DataGridCell>
+                <DataGridCell>
+                  <StatusBadge status={e.status} />
+                </DataGridCell>
+                <DataGridCell>{e.ip_address || "-"}</DataGridCell>
+                <DataGridCell>
+                  <div className="flex flex-wrap gap-1">
+                    {e.tags?.length ? (
+                      e.tags.map((tag) => <Badge key={tag} text={tag} />)
+                    ) : (
+                      <span className="text-theme-light">-</span>
+                    )}
+                  </div>
+                </DataGridCell>
+                {canEdit && (
+                  <DataGridCell>
+                    <Stack gap="1">
+                      <Button
+                        size="small"
+                        icon="edit"
+                        onClick={(ev) => {
+                          ev.stopPropagation();
+                          openEndpointModal(e);
+                        }}
+                      />
+                      <Button
+                        size="small"
+                        icon="deleteForever"
+                        variant="primary-danger"
+                        onClick={(ev) => {
+                          ev.stopPropagation();
+                          openDeleteModal({ type: "endpoint", item: e });
+                        }}
+                      />
+                    </Stack>
+                  </DataGridCell>
+                )}
+              </DataGridRow>
+            );
+          })}
+        </DataGrid>
+
+        {filteredAndSortedEndpoints.length === 0 && endpoints.length > 0 && (
+          <Message variant="info">No endpoints match your filters.</Message>
+        )}
+        {endpoints.length === 0 && <Message variant="info">No endpoints found.</Message>}
+      </Stack>
+
+      <Routes>
+        <Route path=":endpointId" element={<EndpointDetail />} />
+      </Routes>
+
+      {showEndpointModal && <EndpointForm />}
+      {showDeleteModal && deleteTarget?.type === "endpoint" && (
+        <DeleteModal onConfirm={handleDelete} isLoading={del.isPending} error={del.error} />
+      )}
+    </>
+  );
+};

--- a/web/src/components/MigrateModal.tsx
+++ b/web/src/components/MigrateModal.tsx
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState } from "react";
+import { Modal, Stack, Message, Select, SelectOption, FormRow } from "@cloudoperators/juno-ui-components";
+import { useAgents, useMigrateService } from "../api";
+import type { Service } from "../types";
+
+interface MigrateModalProps {
+  service: Service;
+  onClose: () => void;
+}
+
+export const MigrateModal = ({ service, onClose }: MigrateModalProps) => {
+  const [targetHost, setTargetHost] = useState<string>("");
+  const [error, setError] = useState<string | null>(null);
+  const { data: agentsData, isLoading: agentsLoading } = useAgents();
+  const migrate = useMigrateService();
+
+  const agents = agentsData?.items ?? [];
+  // Filter agents: enabled, not current host, same provider type
+  const enabledAgents = agents.filter((a) => a.enabled && a.host !== service.host && a.provider === service.provider);
+
+  const handleMigrate = async () => {
+    setError(null);
+    try {
+      await migrate.mutateAsync({
+        id: service.id,
+        targetHost: targetHost || undefined,
+      });
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Migration failed");
+    }
+  };
+
+  return (
+    <Modal
+      title="Migrate Service"
+      open
+      onCancel={onClose}
+      onConfirm={handleMigrate}
+      confirmButtonLabel={migrate.isPending ? "Migrating..." : "Migrate"}
+      confirmButtonIcon="upload"
+      disableConfirmButton={migrate.isPending}
+    >
+      <Stack direction="vertical" gap="4">
+        {error && <Message variant="danger">{error}</Message>}
+
+        <div className="text-sm">
+          <p>
+            Migrate service <strong>{service.name || service.id}</strong> to another agent.
+          </p>
+          {service.host && (
+            <p className="text-theme-light mt-2">
+              Current host: <code>{service.host}</code>
+            </p>
+          )}
+        </div>
+
+        <FormRow>
+          <Select
+            label="Target Host"
+            value={targetHost}
+            onChange={(v) => setTargetHost(String(v ?? ""))}
+            placeholder="Auto-select (least loaded)"
+            loading={agentsLoading}
+          >
+            {enabledAgents.map((agent) => (
+              <SelectOption key={agent.host} value={agent.host}>
+                {`${agent.host} (${agent.availability_zone || "cross-AZ"}, ${agent.services} services)`}
+              </SelectOption>
+            ))}
+          </Select>
+          <p className="text-xs text-theme-light mt-1">
+            Leave empty to auto-select the least loaded agent in the same availability zone.
+          </p>
+        </FormRow>
+      </Stack>
+    </Modal>
+  );
+};

--- a/web/src/components/NetworkGraph.tsx
+++ b/web/src/components/NetworkGraph.tsx
@@ -1,0 +1,757 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { useMemo, useState, useCallback, useEffect, type MouseEvent } from "react";
+import {
+  ReactFlow,
+  Node,
+  Edge,
+  Background,
+  BackgroundVariant,
+  Controls,
+  MiniMap,
+  useNodesState,
+  useEdgesState,
+  MarkerType,
+  Position,
+  ReactFlowProvider,
+  useReactFlow,
+  Handle,
+  ConnectionLineType,
+} from "@xyflow/react";
+import { LoadingIndicator, Message, Stack } from "@cloudoperators/juno-ui-components";
+import { useServices, useEndpoints, useServiceConsumers } from "../api";
+import { useStore } from "../store";
+import type { Service, Endpoint, EndpointConsumer } from "../types";
+
+// Use Juno CSS variables for status colors
+const STATUS_COLORS: Record<string, string> = {
+  AVAILABLE: "var(--color-success)",
+  ONLINE: "var(--color-success)",
+  PENDING_CREATE: "var(--color-warning)",
+  PENDING_UPDATE: "var(--color-warning)",
+  PENDING_DELETE: "var(--color-warning)",
+  PENDING_APPROVAL: "var(--color-warning)",
+  PENDING_REJECTED: "var(--color-danger)",
+  REJECTED: "var(--color-danger)",
+  FAILED: "var(--color-danger)",
+  ERROR_QUOTA: "var(--color-danger)",
+  UNAVAILABLE: "var(--color-text-light)",
+  DEGRADED: "var(--color-warning)",
+  OFFLINE: "var(--color-danger)",
+  UNCHECKED: "var(--color-text-light)",
+};
+
+const getStatusColor = (status: string | null) => STATUS_COLORS[status || ""] || "var(--color-text-light)";
+
+const isPending = (status: string | null) => status?.startsWith("PENDING") || status === "UNCHECKED";
+
+// Group bubble node
+const GroupBubbleNode = ({
+  data,
+}: {
+  data: { label: string; sublabel?: string; type: "own" | "external" | "managed"; width: number; height: number };
+}) => {
+  const colors = {
+    own: {
+      bg: "color-mix(in srgb, var(--color-success) 10%, transparent)",
+      border: "var(--color-success)",
+      text: "var(--color-success)",
+    },
+    external: {
+      bg: "var(--color-background-lvl-3)",
+      border: "var(--color-text-light)",
+      text: "var(--color-text-light)",
+    },
+    managed: { bg: "rgba(168, 85, 247, 0.1)", border: "rgb(168, 85, 247)", text: "rgb(168, 85, 247)" },
+  };
+  const c = colors[data.type];
+
+  return (
+    <div
+      className="rounded-2xl border-2 border-dashed relative"
+      style={{
+        width: data.width,
+        height: data.height,
+        backgroundColor: c.bg,
+        borderColor: c.border,
+      }}
+    >
+      <div
+        className="absolute -top-3 left-4 px-2 py-0.5 rounded text-xs font-semibold z-10"
+        style={{
+          backgroundColor: "var(--color-background-lvl-0)",
+          borderColor: c.border,
+          color: c.text,
+          border: `1px solid ${c.border}`,
+        }}
+      >
+        {data.label}
+      </div>
+      {data.sublabel && (
+        <div className="absolute top-2 right-3 text-[10px] opacity-60" style={{ color: c.text }}>
+          {data.sublabel}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// Service node
+const ServiceNode = ({
+  data,
+}: {
+  data: { label: string; service: Service; isExternal: boolean; isManaged: boolean };
+}) => {
+  const { service, isExternal, isManaged } = data;
+  // Use darker green for own services to ensure white text contrast
+  const bgColor = isManaged ? "rgb(124, 58, 237)" : isExternal ? "var(--color-background-lvl-4)" : "#16a34a";
+  const textColor = isManaged || !isExternal ? "white" : "var(--color-text-default)";
+  const pending = isPending(service.status);
+  // Show colored border based on service status (not health_status)
+  const isHealthy = service.status === "AVAILABLE";
+  const borderColor = isHealthy ? "transparent" : getStatusColor(service.status);
+
+  return (
+    <div
+      className="px-3 py-2 rounded-lg shadow-lg min-w-[150px] cursor-pointer hover:brightness-110 transition-all"
+      style={{
+        backgroundColor: bgColor,
+        border: isHealthy ? "none" : `3px solid ${borderColor}`,
+        animation: pending ? "pulse-glow 2s ease-in-out infinite" : undefined,
+      }}
+    >
+      <Handle type="target" position={Position.Left} className="!bg-white !w-2.5 !h-2.5 !border-2 !border-gray-600" />
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-sm font-bold truncate max-w-[120px]" style={{ color: textColor }}>
+          {data.label}
+        </span>
+        <span
+          className="w-3 h-3 rounded-full flex-shrink-0 border border-white"
+          style={{ backgroundColor: getStatusColor(service.health_status) }}
+          title={`Health: ${service.health_status || "Unknown"}`}
+        />
+      </div>
+      <div className="text-xs mt-1" style={{ color: textColor, opacity: 0.7 }}>
+        {service.visibility} · {service.protocol}
+      </div>
+    </div>
+  );
+};
+
+// Endpoint node
+const EndpointNode = ({ data }: { data: { label: string; endpoint: Endpoint } }) => {
+  const { endpoint } = data;
+  const pending = isPending(endpoint.status);
+  const isHealthy = endpoint.status === "AVAILABLE";
+  const borderColor = isHealthy ? "transparent" : getStatusColor(endpoint.status);
+
+  return (
+    <div
+      className="px-3 py-2 rounded-full shadow-lg min-w-[130px] cursor-pointer hover:brightness-110 transition-all"
+      style={{
+        backgroundColor: "#0d9488",
+        border: isHealthy ? "none" : `3px solid ${borderColor}`,
+        animation: pending ? "pulse-glow 2s ease-in-out infinite" : undefined,
+      }}
+    >
+      <Handle type="source" position={Position.Right} className="!bg-white !w-2.5 !h-2.5 !border-2 !border-gray-600" />
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-white text-sm font-bold truncate max-w-[90px]">{data.label}</span>
+        <span
+          className="w-3 h-3 rounded-full flex-shrink-0 border border-white"
+          style={{ backgroundColor: getStatusColor(endpoint.status) }}
+          title={`Status: ${endpoint.status}`}
+        />
+      </div>
+      <div className="text-white/60 text-xs mt-0.5 text-center truncate">{endpoint.ip_address}</div>
+    </div>
+  );
+};
+
+const nodeTypes = {
+  service: ServiceNode,
+  endpoint: EndpointNode,
+  groupBubble: GroupBubbleNode,
+};
+
+const NetworkGraphInner = () => {
+  const { data: servicesData, isLoading: servicesLoading, error: servicesError } = useServices();
+  const { data: endpointsData, isLoading: endpointsLoading, error: endpointsError } = useEndpoints();
+  const projectID = useStore((s) => s.globalAPI.projectID);
+  const theme = useStore((s) => s.globalAPI.theme);
+  const { fitView } = useReactFlow();
+  const isDark = theme === "theme-dark";
+
+  const [selectedNode, setSelectedNode] = useState<Node | null>(null);
+  const [isUnlocked, setIsUnlocked] = useState(false);
+
+  const services = useMemo(() => servicesData?.items ?? [], [servicesData]);
+  const endpoints = useMemo(() => endpointsData?.items ?? [], [endpointsData]);
+
+  // Own services that we need to fetch consumers for
+  const ownServices = useMemo(
+    () => services.filter((s) => s.project_id === projectID && s.provider !== "cp"),
+    [services, projectID]
+  );
+
+  const ownServiceIds = useMemo(() => ownServices.map((s) => s.id), [ownServices]);
+  const consumerQueries = useServiceConsumers(ownServiceIds);
+
+  // Stable signature of all consumer data so memos downstream don't fire when nothing changed.
+  // useQueries returns a new array reference every render, so we can't depend on it directly.
+  const consumersSignature = consumerQueries
+    .map((q) => (q.data?.items ?? []).map((c) => `${c.id}:${c.status}:${c.project_id}`).join(","))
+    .join("|");
+
+  // Aggregate all foreign consumers (from other projects, attached to our services)
+  const allForeignConsumers = useMemo(() => {
+    const result: (EndpointConsumer & { service_id: string })[] = [];
+    ownServices.forEach((service, idx) => {
+      const items = consumerQueries[idx]?.data?.items ?? [];
+      for (const c of items) {
+        if (c.project_id !== projectID) {
+          result.push({ ...c, service_id: service.id });
+        }
+      }
+    });
+    return result;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ownServices, consumersSignature, projectID]);
+
+  const { initialNodes, initialEdges } = useMemo(() => {
+    const nodes: Node[] = [];
+    const edges: Edge[] = [];
+
+    // Categorize services
+    const managedServices = services.filter((s) => s.provider === "cp");
+    const ownServicesFiltered = services.filter((s) => s.project_id === projectID && s.provider !== "cp");
+    const externalServices = services.filter((s) => s.project_id !== projectID && s.provider !== "cp");
+
+    // Group external services by project
+    const externalByProject = new Map<string, Service[]>();
+    externalServices.forEach((s) => {
+      if (!externalByProject.has(s.project_id)) externalByProject.set(s.project_id, []);
+      externalByProject.get(s.project_id)!.push(s);
+    });
+
+    // Group foreign consumers by project
+    const foreignByProject = new Map<string, (EndpointConsumer & { service_id: string })[]>();
+    allForeignConsumers.forEach((c) => {
+      if (!foreignByProject.has(c.project_id)) foreignByProject.set(c.project_id, []);
+      foreignByProject.get(c.project_id)!.push(c);
+    });
+
+    // Get own endpoints
+    const ownEndpoints = endpoints.filter((e) => e.project_id === projectID);
+
+    const nodeWidth = 160;
+    const nodeHeight = 55;
+    const nodePadding = 25;
+    const groupPadding = 50;
+    const sectionGap = 60;
+    const verticalGap = 30;
+    const startY = 60;
+
+    // === Calculate foreign consumer groups width first (to position them on the left) ===
+    let foreignGroupMaxWidth = 0;
+    if (foreignByProject.size > 0) {
+      Array.from(foreignByProject.values()).forEach((foreignConsumers) => {
+        const cols = Math.min(foreignConsumers.length, 2);
+        const groupWidth = cols * (nodeWidth + nodePadding) + groupPadding;
+        foreignGroupMaxWidth = Math.max(foreignGroupMaxWidth, groupWidth);
+      });
+    }
+
+    let currentX = 50;
+
+    // === Foreign Consumers (endpoints from other projects using our services) ===
+    // Position them on the left, before the current project
+    let foreignY = startY;
+    Array.from(foreignByProject.entries()).forEach(([foreignProjectId, foreignConsumers]) => {
+      const cols = Math.min(foreignConsumers.length, 2);
+      const rows = Math.ceil(foreignConsumers.length / cols);
+      const groupWidth = cols * (nodeWidth + nodePadding) + groupPadding;
+      const groupHeight = rows * (nodeHeight + nodePadding) + groupPadding + 20;
+
+      nodes.push({
+        id: `group-foreign-${foreignProjectId || "unknown"}`,
+        type: "groupBubble",
+        position: { x: currentX, y: foreignY },
+        data: {
+          label: "External Consumers",
+          sublabel: foreignProjectId || "unknown project",
+          type: "external",
+          width: groupWidth,
+          height: groupHeight,
+        },
+        draggable: isUnlocked,
+        selectable: false,
+        zIndex: -10,
+      });
+
+      foreignConsumers.forEach((c, i) => {
+        const col = i % cols;
+        const row = Math.floor(i / cols);
+        // Create a minimal endpoint-like object for display
+        const truncatedLabel = `${c.id.slice(0, 8)}…`;
+        const consumerAsEndpoint: Endpoint = {
+          id: c.id,
+          service_id: c.service_id,
+          name: truncatedLabel,
+          description: null,
+          status: c.status,
+          project_id: c.project_id,
+          target: {},
+          ip_address: "",
+          tags: [],
+          created_at: "",
+          updated_at: "",
+        };
+        nodes.push({
+          id: `consumer-${c.id}`,
+          type: "endpoint",
+          position: {
+            x: groupPadding / 2 + col * (nodeWidth + nodePadding),
+            y: groupPadding + row * (nodeHeight + nodePadding),
+          },
+          parentId: `group-foreign-${foreignProjectId || "unknown"}`,
+          data: { label: truncatedLabel, endpoint: consumerAsEndpoint },
+        });
+      });
+
+      foreignY += groupHeight + verticalGap;
+    });
+
+    // Move currentX past the foreign consumer groups
+    if (foreignGroupMaxWidth > 0) {
+      currentX += foreignGroupMaxWidth + sectionGap;
+    }
+
+    // === Own Project (Endpoints on left, Services on right) ===
+    if (ownServicesFiltered.length > 0 || ownEndpoints.length > 0) {
+      const endpointCols = 2;
+      const endpointRows = Math.ceil(ownEndpoints.length / endpointCols);
+      const serviceCols = 2;
+      const serviceRows = Math.ceil(ownServicesFiltered.length / serviceCols);
+
+      const endpointsWidth = ownEndpoints.length > 0 ? endpointCols * (nodeWidth + nodePadding) : 0;
+      const servicesWidth = ownServicesFiltered.length > 0 ? serviceCols * (nodeWidth + nodePadding) : 0;
+      const groupWidth =
+        endpointsWidth +
+        servicesWidth +
+        groupPadding +
+        (ownEndpoints.length > 0 && ownServicesFiltered.length > 0 ? 20 : 0);
+
+      const endpointsHeight = ownEndpoints.length > 0 ? endpointRows * (nodeHeight + nodePadding) : 0;
+      const servicesHeight = ownServicesFiltered.length > 0 ? serviceRows * (nodeHeight + nodePadding) : 0;
+      const groupHeight = Math.max(endpointsHeight, servicesHeight) + groupPadding + 20;
+
+      nodes.push({
+        id: "group-own",
+        type: "groupBubble",
+        position: { x: currentX, y: startY },
+        data: { label: "Current Project", sublabel: projectID, type: "own", width: groupWidth, height: groupHeight },
+        draggable: isUnlocked,
+        selectable: false,
+        zIndex: -10,
+      });
+
+      // Add own endpoints on the left
+      ownEndpoints.forEach((e, i) => {
+        const col = i % endpointCols;
+        const row = Math.floor(i / endpointCols);
+        nodes.push({
+          id: `endpoint-${e.id}`,
+          type: "endpoint",
+          position: {
+            x: groupPadding / 2 + col * (nodeWidth + nodePadding),
+            y: groupPadding + row * (nodeHeight + nodePadding),
+          },
+          parentId: "group-own",
+          data: { label: e.name || e.id.slice(0, 8), endpoint: e },
+        });
+      });
+
+      // Add own services on the right
+      const servicesStartX = endpointsWidth + (ownEndpoints.length > 0 ? 20 : 0);
+      ownServicesFiltered.forEach((s, i) => {
+        const col = i % serviceCols;
+        const row = Math.floor(i / serviceCols);
+        nodes.push({
+          id: `service-${s.id}`,
+          type: "service",
+          position: {
+            x: groupPadding / 2 + servicesStartX + col * (nodeWidth + nodePadding),
+            y: groupPadding + row * (nodeHeight + nodePadding),
+          },
+          parentId: "group-own",
+          data: { label: s.name || s.id.slice(0, 8), service: s, isExternal: false, isManaged: false },
+        });
+      });
+
+      currentX += groupWidth + sectionGap;
+    }
+
+    // === Managed Services (Control Plane) ===
+    const managedX = currentX;
+    if (managedServices.length > 0) {
+      const cols = Math.min(managedServices.length, 2);
+      const rows = Math.ceil(managedServices.length / cols);
+      const groupWidth = cols * (nodeWidth + nodePadding) + groupPadding;
+      const groupHeight = rows * (nodeHeight + nodePadding) + groupPadding + 20;
+
+      nodes.push({
+        id: "group-managed",
+        type: "groupBubble",
+        position: { x: currentX, y: startY },
+        data: {
+          label: "Managed Services",
+          sublabel: "Control Plane",
+          type: "managed",
+          width: groupWidth,
+          height: groupHeight,
+        },
+        draggable: isUnlocked,
+        selectable: false,
+        zIndex: -10,
+      });
+
+      managedServices.forEach((s, i) => {
+        const col = i % cols;
+        const row = Math.floor(i / cols);
+        nodes.push({
+          id: `service-${s.id}`,
+          type: "service",
+          position: {
+            x: groupPadding / 2 + col * (nodeWidth + nodePadding),
+            y: groupPadding + row * (nodeHeight + nodePadding),
+          },
+          parentId: "group-managed",
+          data: { label: s.name || s.id.slice(0, 8), service: s, isExternal: false, isManaged: true },
+        });
+      });
+
+      currentX += groupWidth + sectionGap;
+    }
+
+    // === External Services (grouped by project, stacked vertically) ===
+    const externalX = currentX;
+    let externalY = startY;
+
+    Array.from(externalByProject.entries()).forEach(([extProjectId, extServices]) => {
+      const cols = Math.min(extServices.length, 2);
+      const rows = Math.ceil(extServices.length / cols);
+      const groupWidth = cols * (nodeWidth + nodePadding) + groupPadding;
+      const groupHeight = rows * (nodeHeight + nodePadding) + groupPadding + 20;
+
+      nodes.push({
+        id: `group-external-${extProjectId}`,
+        type: "groupBubble",
+        position: { x: externalX, y: externalY },
+        data: {
+          label: "External Services",
+          sublabel: extProjectId,
+          type: "external",
+          width: groupWidth,
+          height: groupHeight,
+        },
+        draggable: isUnlocked,
+        selectable: false,
+        zIndex: -10,
+      });
+
+      extServices.forEach((s, i) => {
+        const col = i % cols;
+        const row = Math.floor(i / cols);
+        nodes.push({
+          id: `service-${s.id}`,
+          type: "service",
+          position: {
+            x: groupPadding / 2 + col * (nodeWidth + nodePadding),
+            y: groupPadding + row * (nodeHeight + nodePadding),
+          },
+          parentId: `group-external-${extProjectId}`,
+          data: { label: s.name || s.id.slice(0, 8), service: s, isExternal: true, isManaged: false },
+        });
+      });
+
+      externalY += groupHeight + verticalGap;
+    });
+
+    // === Create edges from endpoints to services ===
+    endpoints.forEach((e) => {
+      const edgeColor = getStatusColor(e.status);
+
+      edges.push({
+        id: `edge-${e.id}`,
+        source: `endpoint-${e.id}`,
+        target: `service-${e.service_id}`,
+        type: "default",
+        animated: true,
+        zIndex: 1000,
+        style: {
+          stroke: edgeColor,
+          strokeWidth: 2,
+        },
+        markerEnd: { type: MarkerType.ArrowClosed, color: edgeColor, width: 20, height: 20 },
+      });
+    });
+
+    // === Create edges from foreign consumers to own services ===
+    allForeignConsumers.forEach((c) => {
+      const edgeColor = getStatusColor(c.status);
+
+      edges.push({
+        id: `edge-consumer-${c.id}`,
+        source: `consumer-${c.id}`,
+        target: `service-${c.service_id}`,
+        type: "default",
+        animated: true,
+        zIndex: 1000,
+        style: {
+          stroke: edgeColor,
+          strokeWidth: 2,
+        },
+        markerEnd: { type: MarkerType.ArrowClosed, color: edgeColor, width: 20, height: 20 },
+      });
+    });
+
+    return { initialNodes: nodes, initialEdges: edges };
+  }, [services, endpoints, projectID, isUnlocked, allForeignConsumers]);
+
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+
+  useEffect(() => {
+    setNodes(initialNodes);
+    setEdges(initialEdges);
+    if (!isUnlocked) {
+      const t = setTimeout(() => fitView({ padding: 0.15 }), 100);
+      return () => clearTimeout(t);
+    }
+  }, [initialNodes, initialEdges, setNodes, setEdges, fitView, isUnlocked]);
+
+  const onNodeClick = useCallback((_: MouseEvent, node: Node) => {
+    if (node.type === "groupBubble" || node.type === "networkSubgroup") return;
+    setSelectedNode((prev) => (prev?.id === node.id ? null : node));
+  }, []);
+
+  const getNodeDetails = (node: Node) => {
+    if (node.type === "service") {
+      const s = node.data.service as Service;
+      return (
+        <div className="text-xs space-y-1">
+          <div className="font-semibold text-sm mb-2">{s.name || "Unnamed Service"}</div>
+          <div>
+            <span className="text-theme-light">ID:</span> <span className="font-mono text-[10px]">{s.id}</span>
+          </div>
+          <div>
+            <span className="text-theme-light">Status:</span> {s.status}
+          </div>
+          <div>
+            <span className="text-theme-light">Health:</span> {s.health_status}
+          </div>
+          <div>
+            <span className="text-theme-light">Visibility:</span> {s.visibility}
+          </div>
+          <div>
+            <span className="text-theme-light">IPs:</span>{" "}
+            {s.ip_addresses?.map((ip) => ip.replace(/\/32$/, "")).join(", ")}
+          </div>
+          <div>
+            <span className="text-theme-light">Ports:</span> {s.ports?.join(", ")}
+          </div>
+          <div>
+            <span className="text-theme-light">Protocol:</span> {s.protocol}
+          </div>
+          <div>
+            <span className="text-theme-light">Network:</span>{" "}
+            <span className="font-mono text-[10px]">{s.network_id}</span>
+          </div>
+        </div>
+      );
+    } else if (node.type === "endpoint") {
+      const e = node.data.endpoint as Endpoint;
+      const isForeign = e.project_id && e.project_id !== projectID;
+      return (
+        <div className="text-xs space-y-1">
+          <div className="font-semibold text-sm mb-2">{e.name || "Unnamed Endpoint"}</div>
+          <div>
+            <span className="text-theme-light">ID:</span> <span className="font-mono text-[10px]">{e.id}</span>
+          </div>
+          <div>
+            <span className="text-theme-light">Status:</span> {e.status}
+          </div>
+          {isForeign && (
+            <div>
+              <span className="text-theme-light">Project:</span>{" "}
+              <span className="font-mono text-[10px]">{e.project_id}</span>
+            </div>
+          )}
+          {e.ip_address && (
+            <div>
+              <span className="text-theme-light">IP:</span> {e.ip_address}
+            </div>
+          )}
+          {(e.target.network || e.target.subnet || e.target.port) && (
+            <div>
+              <span className="text-theme-light">Target:</span>{" "}
+              <span className="font-mono text-[10px]">{e.target.network || e.target.subnet || e.target.port}</span>
+            </div>
+          )}
+          <div>
+            <span className="text-theme-light">Service:</span>{" "}
+            <span className="font-mono text-[10px]">{e.service_id}</span>
+          </div>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  if (servicesLoading || endpointsLoading) {
+    return <LoadingIndicator className="m-auto" />;
+  }
+
+  if (servicesError || endpointsError) {
+    return <Message variant="danger">{servicesError?.message || endpointsError?.message}</Message>;
+  }
+
+  if (services.length === 0 && endpoints.length === 0) {
+    return <Message variant="info">No services or endpoints to display.</Message>;
+  }
+
+  return (
+    <Stack direction="vertical" gap="4" className="h-full">
+      <div className="flex items-center gap-4 text-sm flex-wrap">
+        <div className="flex items-center gap-2">
+          <div
+            className="w-5 h-5 rounded border-2 border-dashed"
+            style={{ backgroundColor: "rgba(168, 85, 247, 0.15)", borderColor: "rgb(168, 85, 247)" }}
+          />
+          <span>Managed</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <div
+            className="w-5 h-5 rounded border-2 border-dashed"
+            style={{
+              backgroundColor: "color-mix(in srgb, var(--color-success) 10%, transparent)",
+              borderColor: "var(--color-success)",
+            }}
+          />
+          <span>Own Project</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <div
+            className="w-5 h-5 rounded border-2 border-dashed"
+            style={{ backgroundColor: "var(--color-background-lvl-3)", borderColor: "var(--color-text-light)" }}
+          />
+          <span>External</span>
+        </div>
+        <div className="border-l border-theme-background-lvl-4 h-4" />
+        <div className="flex items-center gap-2">
+          <div className="w-4 h-4 rounded" style={{ backgroundColor: "#16a34a" }} />
+          <span>Service</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="w-4 h-4 rounded-full" style={{ backgroundColor: "#0d9488" }} />
+          <span>Endpoint</span>
+        </div>
+        <div className="border-l border-theme-background-lvl-4 h-4" />
+        <div className="flex items-center gap-1">
+          <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: "var(--color-success)" }} />
+          <span className="text-xs">OK</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: "var(--color-warning)" }} />
+          <span className="text-xs">Pending</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: "var(--color-danger)" }} />
+          <span className="text-xs">Error</span>
+        </div>
+      </div>
+
+      <div className="flex gap-4 flex-1" style={{ minHeight: "500px" }}>
+        <div
+          className="flex-1 border border-theme-background-lvl-4 rounded overflow-hidden"
+          style={{
+            background: isDark
+              ? "radial-gradient(ellipse at center, #172033 0%, #0f172a 50%, #030712 100%)"
+              : undefined,
+          }}
+        >
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            onNodeClick={onNodeClick}
+            nodeTypes={nodeTypes}
+            colorMode={isDark ? "dark" : "light"}
+            style={{ background: isDark ? "transparent" : "#f9fafb" }}
+            fitView
+            fitViewOptions={{ padding: 0.15 }}
+            minZoom={0.2}
+            maxZoom={2}
+            connectionLineType={ConnectionLineType.SmoothStep}
+            defaultEdgeOptions={{ type: "smoothstep" }}
+            nodesDraggable={isUnlocked}
+            nodesConnectable={false}
+            elementsSelectable={false}
+            panOnDrag
+            zoomOnScroll
+          >
+            <Background
+              variant={BackgroundVariant.Dots}
+              color={isDark ? "#374151" : "#9ca3af"}
+              gap={24}
+              size={2}
+              bgColor={isDark ? "transparent" : undefined}
+            />
+            <Controls showInteractive={true} onInteractiveChange={setIsUnlocked} />
+            <MiniMap
+              nodeColor={(node) => {
+                if (node.type === "groupBubble" || node.type === "networkSubgroup") return "transparent";
+                if (node.type === "service") {
+                  if (node.data.isManaged) return "#7c3aed";
+                  return node.data.isExternal ? (isDark ? "#6b7280" : "#9ca3af") : "#16a34a";
+                }
+                if (node.type === "endpoint") return "#0d9488";
+                return isDark ? "#374151" : "#9ca3af";
+              }}
+              maskColor={isDark ? "rgba(0, 0, 0, 0.8)" : "rgba(255, 255, 255, 0.8)"}
+              style={{ backgroundColor: isDark ? "#1f2937" : "#f3f4f6" }}
+            />
+          </ReactFlow>
+        </div>
+
+        {selectedNode && (
+          <div className="w-72 p-4 border border-theme-background-lvl-4 rounded bg-theme-background-lvl-2 flex-shrink-0 overflow-auto">
+            <div className="flex items-center justify-between mb-3">
+              <span className="font-semibold text-sm">
+                {selectedNode.type === "service" ? "Service" : "Endpoint"} Details
+              </span>
+              <button
+                onClick={() => setSelectedNode(null)}
+                className="text-theme-light hover:text-white text-lg leading-none"
+              >
+                ×
+              </button>
+            </div>
+            {getNodeDetails(selectedNode)}
+          </div>
+        )}
+      </div>
+    </Stack>
+  );
+};
+
+export const NetworkGraph = () => {
+  return (
+    <ReactFlowProvider>
+      <NetworkGraphInner />
+    </ReactFlowProvider>
+  );
+};

--- a/web/src/components/NetworkPicker.tsx
+++ b/web/src/components/NetworkPicker.tsx
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState } from "react";
+import { PopupPicker } from "./shared/PopupPicker";
+import { useNetworks } from "../api";
+import type { Network } from "../types";
+
+interface NetworkPickerProps {
+  onSelect: (network: Network) => void;
+  disabled?: boolean;
+}
+
+export const NetworkPicker = ({ onSelect, disabled }: NetworkPickerProps) => {
+  const [fetchEnabled, setFetchEnabled] = useState(false);
+  const { data, isLoading, error } = useNetworks(fetchEnabled);
+
+  return (
+    <PopupPicker
+      items={data?.networks ?? []}
+      isLoading={isLoading}
+      error={error}
+      onSelect={onSelect}
+      onOpen={() => setFetchEnabled(true)}
+      disabled={disabled}
+      title="Browse networks"
+      filterPlaceholder="Filter by name or ID..."
+      emptyMessage="No networks found"
+      errorMessage="Failed to load networks"
+    />
+  );
+};

--- a/web/src/components/NotificationBell.tsx
+++ b/web/src/components/NotificationBell.tsx
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState, useEffect } from "react";
+import { Icon, Button } from "@cloudoperators/juno-ui-components";
+import { useStore } from "../store";
+
+const formatDuration = (timestamp: number): string => {
+  const seconds = Math.floor((Date.now() - timestamp) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+};
+
+const variantStyles = {
+  success: "border-l-green-500 bg-green-500/10",
+  warning: "border-l-yellow-500 bg-yellow-500/10",
+  danger: "border-l-red-500 bg-red-500/10",
+};
+
+const variantIcons = {
+  success: "checkCircle",
+  warning: "warning",
+  danger: "dangerous",
+} as const;
+
+export const NotificationBell = () => {
+  const toasts = useStore((s) => s.toasts);
+  const dismissToast = useStore((s) => s.dismissToast);
+  const clearToasts = useStore((s) => s.clearToasts);
+  const [isOpen, setIsOpen] = useState(false);
+  const [, setTick] = useState(0);
+
+  // Update durations every 30 seconds
+  useEffect(() => {
+    const interval = setInterval(() => setTick((t) => t + 1), 30000);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Auto-open when new toast arrives
+  useEffect(() => {
+    if (toasts.length > 0) {
+      setIsOpen(true);
+    }
+  }, [toasts.length]);
+
+  const unreadCount = toasts.length;
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="relative p-2 rounded hover:bg-theme-background-lvl-2 cursor-pointer"
+        title="Notifications"
+      >
+        <Icon icon="comment" size="24" />
+        {unreadCount > 0 && (
+          <span className="absolute -top-1 -right-1 bg-red-500 text-white text-xs rounded-full w-5 h-5 flex items-center justify-center">
+            {unreadCount > 9 ? "9+" : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {isOpen && (
+        <>
+          {/* Backdrop */}
+          <div className="fixed inset-0 z-40" onClick={() => setIsOpen(false)} />
+
+          {/* Dropdown */}
+          <div
+            className="absolute right-0 top-full mt-2 w-80 max-h-96 overflow-y-auto rounded-lg shadow-lg z-50"
+            style={{
+              backgroundColor: "var(--color-background-lvl-1)",
+              border: "1px solid var(--color-background-lvl-3)",
+              color: "var(--color-text-default)",
+            }}
+          >
+            <div
+              className="sticky top-0 p-3 flex items-center justify-between"
+              style={{
+                backgroundColor: "var(--color-background-lvl-1)",
+                borderBottom: "1px solid var(--color-background-lvl-3)",
+              }}
+            >
+              <span className="font-semibold">Notifications</span>
+              {toasts.length > 0 && (
+                <Button size="small" variant="subdued" onClick={clearToasts}>
+                  Clear all
+                </Button>
+              )}
+            </div>
+
+            {toasts.length === 0 ? (
+              <div className="p-4 text-center" style={{ color: "var(--color-text-light)" }}>
+                No notifications
+              </div>
+            ) : (
+              <div>
+                {toasts.map((t) => (
+                  <div
+                    key={t.id}
+                    className={`p-3 border-l-4 flex items-start gap-3 ${variantStyles[t.variant]}`}
+                    style={{ borderBottom: "1px solid var(--color-background-lvl-3)" }}
+                  >
+                    <Icon
+                      icon={variantIcons[t.variant]}
+                      size="20"
+                      className={
+                        t.variant === "success"
+                          ? "text-green-500"
+                          : t.variant === "warning"
+                            ? "text-yellow-500"
+                            : "text-red-500"
+                      }
+                    />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm" style={{ color: "var(--color-text-default)" }}>
+                        {t.message}
+                      </p>
+                      <p className="text-xs mt-1" style={{ color: "var(--color-text-light)" }}>
+                        {formatDuration(t.timestamp)}
+                      </p>
+                    </div>
+                    <button
+                      onClick={() => dismissToast(t.id)}
+                      className="cursor-pointer"
+                      style={{ color: "var(--color-text-light)" }}
+                    >
+                      <Icon icon="close" size="16" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};

--- a/web/src/components/PortPicker.tsx
+++ b/web/src/components/PortPicker.tsx
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState } from "react";
+import { PopupPicker } from "./shared/PopupPicker";
+import { usePorts } from "../api";
+import type { Port } from "../types";
+
+interface PortPickerProps {
+  onSelect: (port: Port) => void;
+  disabled?: boolean;
+}
+
+export const PortPicker = ({ onSelect, disabled }: PortPickerProps) => {
+  const [fetchEnabled, setFetchEnabled] = useState(false);
+  const { data, isLoading, error } = usePorts(fetchEnabled);
+
+  return (
+    <PopupPicker
+      items={data?.ports ?? []}
+      isLoading={isLoading}
+      error={error}
+      onSelect={onSelect}
+      onOpen={() => setFetchEnabled(true)}
+      disabled={disabled}
+      title="Browse ports"
+      filterPlaceholder="Filter by name, ID, or IP..."
+      emptyMessage="No unbound ports found"
+      errorMessage="Failed to load ports"
+      renderItem={(port) => (
+        <div className="flex flex-col items-start gap-0.5">
+          <span className="font-medium">{port.name || "(unnamed)"}</span>
+          <span className="text-xs text-theme-light">
+            {port.fixed_ips.map((ip) => ip.ip_address).join(", ") || "No IPs"}
+          </span>
+          <span className="text-xs text-theme-light font-mono">{port.id}</span>
+        </div>
+      )}
+      filterFn={(port, search) =>
+        (port.name?.toLowerCase().includes(search.toLowerCase()) ?? false) ||
+        port.id.toLowerCase().includes(search.toLowerCase()) ||
+        port.fixed_ips.some((ip) => ip.ip_address.includes(search))
+      }
+    />
+  );
+};

--- a/web/src/components/RBACForm.tsx
+++ b/web/src/components/RBACForm.tsx
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState, useEffect } from "react";
+import { Modal, TextInput, Stack, FormRow, Message } from "@cloudoperators/juno-ui-components";
+import { useStore } from "../store";
+import { useCreateRBAC, useUpdateRBAC } from "../api";
+import { ServicePicker } from "./ServicePicker";
+import type { RBACPolicyCreate, RBACPolicyUpdate, Service } from "../types";
+
+export const RBACForm = () => {
+  const { editRBAC, closeModals } = useStore();
+  const isEdit = !!editRBAC;
+  const create = useCreateRBAC();
+  const update = useUpdateRBAC();
+
+  const [form, setForm] = useState({ service_id: "", service_name: "", target: "" });
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (editRBAC) {
+      setForm({ service_id: editRBAC.service_id, service_name: "", target: editRBAC.target });
+    }
+  }, [editRBAC]);
+
+  const set = <K extends keyof typeof form>(k: K, v: string) => {
+    setForm((f) => ({ ...f, [k]: v }));
+    setError(null);
+  };
+
+  const handleServiceSelect = (service: Service) => {
+    set("service_id", service.id);
+    setForm((f) => ({ ...f, service_name: service.name || service.id }));
+  };
+
+  const submit = async () => {
+    if (!isEdit && !form.service_id) return setError("Service required");
+    if (!form.target.trim()) return setError("Target project ID required");
+
+    try {
+      if (isEdit) {
+        const data: RBACPolicyUpdate = { target: form.target.trim() };
+        await update.mutateAsync({ id: editRBAC!.id, data });
+      } else {
+        const data: RBACPolicyCreate = {
+          service_id: form.service_id,
+          target: form.target.trim(),
+        };
+        await create.mutateAsync(data);
+      }
+      closeModals();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Unknown error");
+    }
+  };
+
+  const pending = create.isPending || update.isPending;
+
+  return (
+    <Modal
+      title={isEdit ? "Edit RBAC Policy" : "Create RBAC Policy"}
+      open
+      onCancel={closeModals}
+      onConfirm={submit}
+      confirmButtonLabel={pending ? "Saving..." : isEdit ? "Update" : "Create"}
+      confirmButtonIcon={isEdit ? "edit" : "addCircle"}
+      disableConfirmButton={pending}
+    >
+      <Stack direction="vertical" gap="4">
+        {error && <Message variant="danger">{error}</Message>}
+
+        {!isEdit && (
+          <FormRow>
+            <div className="flex gap-2 items-end">
+              <div className="flex-1">
+                <TextInput
+                  label="Service"
+                  value={form.service_name || form.service_id}
+                  onChange={(e) => {
+                    set("service_id", e.target.value);
+                    setForm((f) => ({ ...f, service_name: "" }));
+                  }}
+                  placeholder="Service ID"
+                  required
+                />
+              </div>
+              <ServicePicker onSelect={handleServiceSelect} />
+            </div>
+          </FormRow>
+        )}
+
+        <FormRow>
+          <TextInput
+            label="Target Project ID"
+            value={form.target}
+            onChange={(e) => set("target", e.target.value)}
+            placeholder="32-char project ID or * for all"
+            required
+          />
+        </FormRow>
+
+        <p className="text-xs text-theme-light flex items-center gap-1">
+          <span className="w-2 h-2 rounded-full jn:bg-theme-required" />
+          Required fields
+        </p>
+      </Stack>
+    </Modal>
+  );
+};

--- a/web/src/components/RBACList.tsx
+++ b/web/src/components/RBACList.tsx
@@ -1,0 +1,240 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState, useMemo } from "react";
+import {
+  DataGrid,
+  DataGridRow,
+  DataGridCell,
+  DataGridHeadCell,
+  Button,
+  Stack,
+  LoadingIndicator,
+  Message,
+  Icon,
+  TextInput,
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@cloudoperators/juno-ui-components";
+import { useRBACPolicies, useDeleteRBAC, useServices } from "../api";
+import { useStore } from "../store";
+import { DeleteModal } from "./DeleteModal";
+import { RBACForm } from "./RBACForm";
+
+type SortField = "id" | "service_id" | "target";
+type SortDir = "asc" | "desc";
+
+const SortableHeader = ({
+  label,
+  field,
+  sortField,
+  sortDir,
+  onSort,
+}: {
+  label: string;
+  field: SortField;
+  sortField: SortField | null;
+  sortDir: SortDir;
+  onSort: (field: SortField) => void;
+}) => (
+  <DataGridHeadCell>
+    <button className="flex items-center gap-1 hover:text-theme-accent cursor-pointer" onClick={() => onSort(field)}>
+      {label}
+      {sortField === field && <Icon icon={sortDir === "asc" ? "expandLess" : "expandMore"} size="16" />}
+    </button>
+  </DataGridHeadCell>
+);
+
+export const RBACList = ({ canEdit }: { canEdit: boolean }) => {
+  const { data, isLoading, error } = useRBACPolicies();
+  const { data: servicesData } = useServices();
+  const del = useDeleteRBAC();
+  const { showRBACModal, showDeleteModal, deleteTarget, openRBACModal, openDeleteModal, closeModals } = useStore();
+
+  // Copy to clipboard state
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  const copyToClipboard = (id: string) => {
+    navigator.clipboard.writeText(id);
+    setCopiedId(id);
+    setTimeout(() => setCopiedId(null), 2000);
+  };
+
+  // Create service name lookup
+  const serviceNameMap = useMemo(() => {
+    const map = new Map<string, string>();
+    servicesData?.items?.forEach((s) => {
+      map.set(s.id, s.name || "Unnamed");
+    });
+    return map;
+  }, [servicesData]);
+
+  // Filter state
+  const [filter, setFilter] = useState("");
+
+  // Sort state
+  const [sortField, setSortField] = useState<SortField | null>(null);
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+
+  const policies = data?.items ?? [];
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDir(sortDir === "asc" ? "desc" : "asc");
+    } else {
+      setSortField(field);
+      setSortDir("asc");
+    }
+  };
+
+  const filteredAndSortedPolicies = useMemo(() => {
+    let result = policies.filter((p) => {
+      if (
+        filter &&
+        !(
+          p.id.toLowerCase().includes(filter.toLowerCase()) ||
+          p.service_id.toLowerCase().includes(filter.toLowerCase()) ||
+          p.target.toLowerCase().includes(filter.toLowerCase())
+        )
+      ) {
+        return false;
+      }
+      return true;
+    });
+
+    if (sortField) {
+      result = [...result].sort((a, b) => {
+        const aVal = a[sortField] || "";
+        const bVal = b[sortField] || "";
+        const cmp = String(aVal).localeCompare(String(bVal));
+        return sortDir === "asc" ? cmp : -cmp;
+      });
+    }
+
+    return result;
+  }, [policies, filter, sortField, sortDir]);
+
+  const handleDelete = async () => {
+    if (deleteTarget?.type === "rbac") {
+      try {
+        await del.mutateAsync(deleteTarget.item.id);
+        closeModals();
+      } catch {
+        // Error is captured in del.error, displayed by DeleteModal
+      }
+    }
+  };
+
+  const clearFilters = () => {
+    setFilter("");
+  };
+
+  const hasFilters = filter;
+
+  if (isLoading) return <LoadingIndicator className="m-auto" />;
+  if (error) return <Message variant="danger">{error.message}</Message>;
+
+  return (
+    <>
+      <Stack direction="vertical" gap="4">
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: "1rem",
+            flexWrap: "wrap",
+          }}
+        >
+          <div
+            style={{ display: "flex", flexDirection: "row", alignItems: "center", gap: "0.75rem", flexWrap: "wrap" }}
+          >
+            <div style={{ width: "14rem" }}>
+              <TextInput
+                placeholder="Filter by ID, service, target..."
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+              />
+            </div>
+            {hasFilters && (
+              <Button variant="subdued" onClick={clearFilters}>
+                Clear Filters
+              </Button>
+            )}
+          </div>
+          {canEdit && (
+            <Button icon="addCircle" onClick={() => openRBACModal()}>
+              Create RBAC Policy
+            </Button>
+          )}
+        </div>
+
+        <DataGrid columns={canEdit ? 5 : 4}>
+          <DataGridRow>
+            <SortableHeader label="ID" field="id" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
+            <SortableHeader
+              label="Service"
+              field="service_id"
+              sortField={sortField}
+              sortDir={sortDir}
+              onSort={handleSort}
+            />
+            <DataGridHeadCell>Target Type</DataGridHeadCell>
+            <SortableHeader label="Target" field="target" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
+            {canEdit && <DataGridHeadCell>Actions</DataGridHeadCell>}
+          </DataGridRow>
+          {filteredAndSortedPolicies.map((p) => (
+            <DataGridRow key={p.id}>
+              <DataGridCell>
+                <div className="flex items-center gap-1">
+                  <span>{p.id.slice(0, 16)}...</span>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button onClick={() => copyToClipboard(p.id)} className="hover:text-theme-accent cursor-pointer">
+                        <Icon icon={copiedId === p.id ? "checkCircle" : "contentCopy"} size="16" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>{copiedId === p.id ? "Copied!" : p.id}</TooltipContent>
+                  </Tooltip>
+                </div>
+              </DataGridCell>
+              <DataGridCell>
+                <div className="flex flex-col">
+                  <span className="font-semibold">{serviceNameMap.get(p.service_id) || "Unknown"}</span>
+                  <span className="text-xs text-theme-light">{p.service_id}</span>
+                </div>
+              </DataGridCell>
+              <DataGridCell>{p.target_type}</DataGridCell>
+              <DataGridCell>{p.target}</DataGridCell>
+              {canEdit && (
+                <DataGridCell>
+                  <Stack gap="1">
+                    <Button size="small" icon="edit" onClick={() => openRBACModal(p)} />
+                    <Button
+                      size="small"
+                      icon="deleteForever"
+                      variant="primary-danger"
+                      onClick={() => openDeleteModal({ type: "rbac", item: p })}
+                    />
+                  </Stack>
+                </DataGridCell>
+              )}
+            </DataGridRow>
+          ))}
+        </DataGrid>
+
+        {filteredAndSortedPolicies.length === 0 && policies.length > 0 && (
+          <Message variant="info">No RBAC policies match your filters.</Message>
+        )}
+        {policies.length === 0 && <Message variant="info">No RBAC policies.</Message>}
+      </Stack>
+
+      {showRBACModal && <RBACForm />}
+      {showDeleteModal && deleteTarget?.type === "rbac" && (
+        <DeleteModal onConfirm={handleDelete} isLoading={del.isPending} error={del.error} />
+      )}
+    </>
+  );
+};

--- a/web/src/components/ServiceDetail.tsx
+++ b/web/src/components/ServiceDetail.tsx
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState, useMemo } from "react";
+import {
+  Panel,
+  PanelBody,
+  PanelFooter,
+  Button,
+  DataGrid,
+  DataGridRow,
+  DataGridCell,
+  DataGridHeadCell,
+  LoadingIndicator,
+  Message,
+  Stack,
+  Tabs,
+  Tab,
+  TabList,
+  TabPanel,
+} from "@cloudoperators/juno-ui-components";
+import { useParams, useNavigate } from "react-router";
+import { useService, useServiceEndpoints, useEndpoints, useAcceptEndpoints, useRejectEndpoints } from "../api";
+import { StatusBadge } from "./StatusBadge";
+
+const formatPorts = (ports: number[] | null | undefined): string => {
+  if (!ports || ports.length === 0) return "-";
+
+  const sorted = [...ports].sort((a, b) => a - b);
+  const ranges: string[] = [];
+  let start = sorted[0];
+  let end = sorted[0];
+
+  for (let i = 1; i <= sorted.length; i++) {
+    if (i < sorted.length && sorted[i] === end + 1) {
+      end = sorted[i];
+    } else {
+      ranges.push(start === end ? String(start) : `${start}-${end}`);
+      if (i < sorted.length) {
+        start = sorted[i];
+        end = sorted[i];
+      }
+    }
+  }
+
+  return ranges.join(", ");
+};
+
+export const ServiceDetail = ({ canEdit }: { canEdit: boolean }) => {
+  const { serviceId } = useParams<{ serviceId: string }>();
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState(0);
+
+  const { data: service, isLoading, error } = useService(serviceId);
+  const { data: consumersData, isLoading: consumersLoading } = useServiceEndpoints(serviceId);
+  const { data: endpointsData } = useEndpoints();
+  const accept = useAcceptEndpoints();
+  const reject = useRejectEndpoints();
+
+  const consumers = consumersData?.items ?? [];
+  const endpoints = endpointsData?.items ?? [];
+  const close = () => navigate("/services");
+
+  // Create a map of endpoint ID to endpoint name
+  const endpointNameMap = useMemo(() => {
+    const map = new Map<string, string | null>();
+    endpoints.forEach((e) => map.set(e.id, e.name));
+    return map;
+  }, [endpoints]);
+
+  const handleAcceptIds = async (ids: string[]) => {
+    if (serviceId) {
+      await accept.mutateAsync({ serviceId, endpointIds: ids });
+    }
+  };
+
+  const handleRejectIds = async (ids: string[]) => {
+    if (serviceId) {
+      await reject.mutateAsync({ serviceId, endpointIds: ids });
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Panel heading="Service Details" opened onClose={close}>
+        <PanelBody>
+          <LoadingIndicator className="m-auto" />
+        </PanelBody>
+      </Panel>
+    );
+  }
+
+  if (error || !service) {
+    return (
+      <Panel heading="Service Details" opened onClose={close}>
+        <PanelBody>
+          <Message variant="danger">{error?.message || "Not found"}</Message>
+        </PanelBody>
+      </Panel>
+    );
+  }
+
+  const fmt = (d: string | undefined) => (d ? new Date(d).toLocaleString() : "-");
+
+  const panelHeading = service.name || "Service Details";
+
+  return (
+    <Panel heading={panelHeading} opened onClose={close}>
+      <PanelBody>
+        <Tabs selectedIndex={activeTab} onSelect={setActiveTab}>
+          <TabList>
+            <Tab>Details</Tab>
+            <Tab>Consumers ({consumers.length})</Tab>
+          </TabList>
+
+          <TabPanel>
+            <DataGrid columns={2} className="mt-4">
+              {[
+                ["ID", service.id],
+                ["Name", service.name || "-"],
+                ["Description", service.description || "-"],
+                ["Provider", service.provider === "cp" ? "Control Plane" : "Tenant"],
+                ["Host", service.host || "-"],
+                ["Status", <StatusBadge key="s" status={service.status} />],
+                ["Health", <StatusBadge key="h" status={service.health_status} />],
+                ["Enabled", service.enabled ? "Yes" : "No"],
+                ["Visibility", service.visibility],
+                ["Require Approval", service.require_approval ? "Yes" : "No"],
+                ["Protocol", service.protocol],
+                ["Ports", formatPorts(service.ports)],
+                ["IP Addresses", service.ip_addresses?.map((ip) => ip.replace(/\/32$/, "")).join(", ") || "-"],
+                ["Network ID", service.network_id],
+                ["Availability Zone", service.availability_zone || "-"],
+                ["Proxy Protocol", service.proxy_protocol ? "Yes" : "No"],
+                ["Connection Mirroring", service.connection_mirroring ? "Yes" : "No"],
+                ["Tags", service.tags?.join(", ") || "-"],
+                ["Project", service.project_id],
+                ["Created", fmt(service.created_at)],
+                ["Updated", fmt(service.updated_at)],
+              ].map(([label, value], i) => (
+                <DataGridRow key={i}>
+                  <DataGridCell className="font-semibold">{label}</DataGridCell>
+                  <DataGridCell>{value}</DataGridCell>
+                </DataGridRow>
+              ))}
+            </DataGrid>
+          </TabPanel>
+
+          <TabPanel>
+            {consumersLoading ? (
+              <LoadingIndicator className="m-auto mt-4" />
+            ) : (
+              <Stack direction="vertical" gap="4" className="mt-4">
+                {consumers.length > 0 && (
+                  <DataGrid columns={canEdit ? 5 : 3}>
+                    <DataGridRow>
+                      <DataGridHeadCell>Endpoint</DataGridHeadCell>
+                      <DataGridHeadCell>Project ID</DataGridHeadCell>
+                      <DataGridHeadCell>Status</DataGridHeadCell>
+                      {canEdit && <DataGridHeadCell>Accept</DataGridHeadCell>}
+                      {canEdit && <DataGridHeadCell>Reject</DataGridHeadCell>}
+                    </DataGridRow>
+                    {consumers.map((c) => (
+                      <DataGridRow key={c.id}>
+                        <DataGridCell>
+                          <div className="flex flex-col">
+                            <div className="flex items-center gap-1">
+                              <span className="font-semibold">{endpointNameMap.get(c.id) || "Unnamed"}</span>
+                            </div>
+                            <span className="text-xs text-theme-light">{c.id}</span>
+                          </div>
+                        </DataGridCell>
+                        <DataGridCell className="text-xs">{c.project_id}</DataGridCell>
+                        <DataGridCell>
+                          <StatusBadge status={c.status} />
+                        </DataGridCell>
+                        {canEdit && (
+                          <DataGridCell>
+                            {(c.status === "REJECTED" || c.status === "PENDING_APPROVAL") && (
+                              <Button
+                                size="small"
+                                onClick={() => handleAcceptIds([c.id])}
+                                disabled={accept.isPending || reject.isPending}
+                              >
+                                Accept
+                              </Button>
+                            )}
+                          </DataGridCell>
+                        )}
+                        {canEdit && (
+                          <DataGridCell>
+                            {(c.status === "AVAILABLE" || c.status === "PENDING_APPROVAL") && (
+                              <Button
+                                size="small"
+                                variant="primary-danger"
+                                onClick={() => handleRejectIds([c.id])}
+                                disabled={accept.isPending || reject.isPending}
+                              >
+                                Reject
+                              </Button>
+                            )}
+                          </DataGridCell>
+                        )}
+                      </DataGridRow>
+                    ))}
+                  </DataGrid>
+                )}
+
+                {consumers.length === 0 && <Message variant="info">No consumers.</Message>}
+              </Stack>
+            )}
+          </TabPanel>
+        </Tabs>
+      </PanelBody>
+      <PanelFooter>
+        <Button onClick={close}>Close</Button>
+      </PanelFooter>
+    </Panel>
+  );
+};

--- a/web/src/components/ServiceForm.tsx
+++ b/web/src/components/ServiceForm.tsx
@@ -1,0 +1,287 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState, useEffect } from "react";
+import {
+  Modal,
+  TextInput,
+  Textarea,
+  Select,
+  SelectOption,
+  Switch,
+  Stack,
+  FormRow,
+  Message,
+} from "@cloudoperators/juno-ui-components";
+import { useStore } from "../store";
+import { useCreateService, useUpdateService } from "../api";
+import { NetworkPicker } from "./NetworkPicker";
+import type { ServiceCreate, ServiceUpdate, Visibility, Protocol, Network, Provider } from "../types";
+
+export const ServiceForm = () => {
+  const { editService, createServiceProvider, closeModals } = useStore();
+  const neutronEndpoint = useStore((s) => s.globalAPI.neutronEndpoint);
+  const isEdit = !!editService;
+  const create = useCreateService();
+  const update = useUpdateService();
+
+  const [form, setForm] = useState({
+    name: "",
+    description: "",
+    network_id: "",
+    ip_addresses: "",
+    ports: "",
+    enabled: true,
+    visibility: "private" as Visibility,
+    require_approval: false,
+    proxy_protocol: false,
+    connection_mirroring: false,
+    protocol: "TCP" as Protocol,
+    tags: "",
+  });
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (editService) {
+      setForm({
+        name: editService.name ?? "",
+        description: editService.description ?? "",
+        network_id: editService.network_id,
+        ip_addresses: formatIPs(editService.ip_addresses),
+        ports: editService.ports?.join(", ") ?? "",
+        enabled: editService.enabled,
+        visibility: editService.visibility,
+        require_approval: editService.require_approval,
+        proxy_protocol: editService.proxy_protocol,
+        connection_mirroring: editService.connection_mirroring,
+        protocol: editService.protocol,
+        tags: editService.tags?.join(", ") ?? "",
+      });
+    }
+  }, [editService]);
+
+  const set = <K extends keyof typeof form>(k: K, v: (typeof form)[K]) => {
+    setForm((f) => ({ ...f, [k]: v }));
+    setError(null);
+  };
+
+  const parseList = (s: string) =>
+    s
+      .split(",")
+      .map((x) => x.trim())
+      .filter(Boolean);
+  const parseIPs = (s: string) => parseList(s).map((ip) => ip.replace(/\/32$/, ""));
+  const parsePorts = (s: string) =>
+    parseList(s)
+      .map((x) => parseInt(x, 10))
+      .filter((n) => !isNaN(n));
+  const formatIPs = (ips: string[] | undefined) => ips?.map((ip) => ip.replace(/\/32$/, "")).join(", ") ?? "";
+
+  const submit = async () => {
+    const isNI = createServiceProvider === "cp";
+    if (!isNI && !form.network_id.trim()) return setError("Network ID required");
+    if (!form.ip_addresses.trim()) return setError("IP addresses required");
+    if (!form.ports.trim()) return setError("Ports required");
+
+    try {
+      if (isEdit) {
+        const newIPs = parseIPs(form.ip_addresses);
+        const newPorts = parsePorts(form.ports);
+        const oldIPs = editService!.ip_addresses?.map((ip) => ip.replace(/\/32$/, "")) ?? [];
+        const oldPorts = editService!.ports ?? [];
+
+        // Only include ip_addresses/ports if they changed to avoid 409 conflict
+        const ipsChanged = JSON.stringify(newIPs.sort()) !== JSON.stringify(oldIPs.sort());
+        const portsChanged = JSON.stringify(newPorts.sort()) !== JSON.stringify(oldPorts.sort());
+
+        const data: ServiceUpdate = {
+          name: form.name || null,
+          description: form.description || null,
+          enabled: form.enabled,
+          visibility: form.visibility,
+          require_approval: form.require_approval,
+          proxy_protocol: form.proxy_protocol,
+          connection_mirroring: form.connection_mirroring,
+          protocol: form.protocol,
+          tags: parseList(form.tags),
+        };
+        if (ipsChanged) data.ip_addresses = newIPs;
+        if (portsChanged) data.ports = newPorts;
+
+        await update.mutateAsync({ id: editService!.id, data });
+      } else {
+        const data: ServiceCreate = {
+          name: form.name || undefined,
+          description: form.description || undefined,
+          network_id: isNI ? "00000000-0000-0000-0000-000000000000" : form.network_id.trim(),
+          ip_addresses: parseIPs(form.ip_addresses),
+          ports: parsePorts(form.ports),
+          enabled: form.enabled,
+          visibility: form.visibility,
+          require_approval: form.require_approval,
+          proxy_protocol: isNI ? undefined : form.proxy_protocol,
+          connection_mirroring: isNI ? undefined : form.connection_mirroring,
+          protocol: form.protocol,
+          tags: parseList(form.tags),
+          provider: createServiceProvider ?? undefined,
+        };
+        await create.mutateAsync(data);
+      }
+      closeModals();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Unknown error");
+    }
+  };
+
+  const handleNetworkSelect = (network: Network) => {
+    set("network_id", network.id);
+  };
+
+  const pending = create.isPending || update.isPending;
+
+  const getTitle = () => {
+    if (isEdit) return "Edit Service";
+    if (createServiceProvider === "cp") return "Create Control Plane Service";
+    return "Create Service";
+  };
+
+  return (
+    <Modal
+      title={getTitle()}
+      open
+      onCancel={closeModals}
+      onConfirm={submit}
+      confirmButtonLabel={pending ? "Saving..." : isEdit ? "Update" : "Create"}
+      confirmButtonIcon={isEdit ? "edit" : "addCircle"}
+      disableConfirmButton={pending}
+    >
+      <Stack direction="vertical" gap="4">
+        {error && <Message variant="danger">{error}</Message>}
+
+        <div className="flex items-center justify-between bg-theme-background-lvl-2 rounded p-3">
+          <span className="font-semibold">Enabled</span>
+          <Switch on={form.enabled} onClick={() => set("enabled", !form.enabled)} />
+        </div>
+
+        <FormRow>
+          <TextInput label="Name" value={form.name} onChange={(e) => set("name", e.target.value)} />
+        </FormRow>
+        <FormRow>
+          <Textarea label="Description" value={form.description} onChange={(e) => set("description", e.target.value)} />
+        </FormRow>
+
+        <fieldset className="border border-theme-background-lvl-4 rounded p-4">
+          <legend className="px-2 text-sm font-semibold text-theme-light">Network Configuration</legend>
+          <Stack direction="vertical" gap="4">
+            {createServiceProvider !== "cp" && (
+              <FormRow>
+                <div className="flex gap-2 items-end">
+                  <div className="flex-1">
+                    <TextInput
+                      label="Network ID"
+                      value={form.network_id}
+                      onChange={(e) => set("network_id", e.target.value)}
+                      disabled={isEdit}
+                      required
+                    />
+                  </div>
+                  {neutronEndpoint && !isEdit && <NetworkPicker onSelect={handleNetworkSelect} />}
+                </div>
+              </FormRow>
+            )}
+            <FormRow>
+              <TextInput
+                label="IP Addresses"
+                value={form.ip_addresses}
+                onChange={(e) => set("ip_addresses", e.target.value)}
+                placeholder="10.0.1.10, 10.0.1.11"
+                helptext="Backend IP addresses (multiple IPs are round-robin load balanced)"
+                required
+              />
+            </FormRow>
+            <div className="flex gap-4">
+              <div className="flex-1">
+                <FormRow>
+                  <TextInput
+                    label="Ports"
+                    value={form.ports}
+                    onChange={(e) => set("ports", e.target.value)}
+                    placeholder="80, 443"
+                    helptext="Backend ports to expose"
+                    required
+                  />
+                </FormRow>
+              </div>
+              <div className="flex-1">
+                <FormRow>
+                  <Select label="Protocol" value={form.protocol} onChange={(v) => set("protocol", v as Protocol)}>
+                    <SelectOption value="TCP">TCP</SelectOption>
+                    <SelectOption value="HTTP">HTTP</SelectOption>
+                  </Select>
+                </FormRow>
+              </div>
+            </div>
+          </Stack>
+        </fieldset>
+
+        <div className="flex items-center justify-between">
+          <div>
+            <span>Public Visibility</span>
+            <p className="text-xs text-theme-light">Make this service visible to all projects</p>
+          </div>
+          <Switch
+            on={form.visibility === "public"}
+            onClick={() => set("visibility", form.visibility === "public" ? "private" : "public")}
+          />
+        </div>
+        <Stack direction="vertical" gap="4">
+          <div className="flex items-center justify-between">
+            <div>
+              <span>Require Approval</span>
+              <p className="text-xs text-theme-light">Endpoint requests must be approved before activation</p>
+            </div>
+            <Switch on={form.require_approval} onClick={() => set("require_approval", !form.require_approval)} />
+          </div>
+          {createServiceProvider !== "cp" && (
+            <>
+              <div className="flex items-center justify-between">
+                <div>
+                  <span>Proxy Protocol v2</span>
+                  <p className="text-xs text-theme-light">Prepend proxy protocol header to TCP payload</p>
+                </div>
+                <Switch on={form.proxy_protocol} onClick={() => set("proxy_protocol", !form.proxy_protocol)} />
+              </div>
+              <div className="flex items-center justify-between">
+                <div>
+                  <span>Connection Mirroring</span>
+                  <p className="text-xs text-theme-light">
+                    Enable BIG-IP connection mirroring for HA failover (may increase latency)
+                  </p>
+                </div>
+                <Switch
+                  on={form.connection_mirroring}
+                  onClick={() => set("connection_mirroring", !form.connection_mirroring)}
+                />
+              </div>
+            </>
+          )}
+        </Stack>
+
+        <FormRow>
+          <TextInput
+            label="Tags"
+            value={form.tags}
+            onChange={(e) => set("tags", e.target.value)}
+            placeholder="production, team:network"
+            helptext="Comma-separated tags for organization"
+          />
+        </FormRow>
+
+        <p className="text-xs text-theme-light flex items-center gap-1">
+          <span className="w-2 h-2 rounded-full jn:bg-theme-required" />
+          Required fields
+        </p>
+      </Stack>
+    </Modal>
+  );
+};

--- a/web/src/components/ServiceList.tsx
+++ b/web/src/components/ServiceList.tsx
@@ -1,0 +1,475 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState, useMemo } from "react";
+import {
+  DataGrid,
+  DataGridRow,
+  DataGridCell,
+  DataGridHeadCell,
+  Button,
+  Stack,
+  LoadingIndicator,
+  Message,
+  Icon,
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  Badge,
+  TextInput,
+  Select,
+  SelectOption,
+} from "@cloudoperators/juno-ui-components";
+import { Routes, Route, useNavigate, useLocation } from "react-router";
+import { useServices, useDeleteService } from "../api";
+import { useStore } from "../store";
+import { useStatusChangeToast } from "../hooks/useStatusChangeToast";
+import { StatusBadge } from "./StatusBadge";
+import { DeleteModal } from "./DeleteModal";
+import { ServiceDetail } from "./ServiceDetail";
+import { ServiceForm } from "./ServiceForm";
+import { EndpointForm } from "./EndpointForm";
+import { MigrateModal } from "./MigrateModal";
+import type { Service, Provider } from "../types";
+
+const ProviderLabel = ({ provider }: { provider: Provider | null }) => {
+  const isCP = provider === "cp";
+  return <span>{isCP ? "Control Plane" : "Tenant"}</span>;
+};
+
+const EnabledIcon = ({ enabled }: { enabled: boolean }) => (
+  <Tooltip>
+    <TooltipTrigger>
+      <Icon
+        icon={enabled ? "checkCircle" : "cancel"}
+        size="18"
+        className={enabled ? "text-green-500" : "text-red-500"}
+      />
+    </TooltipTrigger>
+    <TooltipContent>{enabled ? "Enabled" : "Disabled"}</TooltipContent>
+  </Tooltip>
+);
+
+const formatPorts = (ports: number[] | null | undefined): string => {
+  if (!ports || ports.length === 0) return "-";
+
+  const sorted = [...ports].sort((a, b) => a - b);
+  const ranges: string[] = [];
+  let start = sorted[0];
+  let end = sorted[0];
+
+  for (let i = 1; i <= sorted.length; i++) {
+    if (i < sorted.length && sorted[i] === end + 1) {
+      end = sorted[i];
+    } else {
+      ranges.push(start === end ? String(start) : `${start}-${end}`);
+      if (i < sorted.length) {
+        start = sorted[i];
+        end = sorted[i];
+      }
+    }
+  }
+
+  return ranges.join(", ");
+};
+
+type SortField = "name" | "status" | "health_status" | "visibility" | "enabled" | "provider";
+type SortDir = "asc" | "desc";
+
+const SortableHeader = ({
+  label,
+  field,
+  sortField,
+  sortDir,
+  onSort,
+}: {
+  label: string;
+  field: SortField;
+  sortField: SortField | null;
+  sortDir: SortDir;
+  onSort: (field: SortField) => void;
+}) => (
+  <DataGridHeadCell>
+    <button className="flex items-center gap-1 hover:text-theme-accent cursor-pointer" onClick={() => onSort(field)}>
+      {label}
+      {sortField === field && <Icon icon={sortDir === "asc" ? "expandLess" : "expandMore"} size="16" />}
+    </button>
+  </DataGridHeadCell>
+);
+
+export const ServiceList = ({ canEdit, cloudAdmin }: { canEdit: boolean; cloudAdmin: boolean }) => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { data, isLoading, error } = useServices();
+  const deleteService = useDeleteService();
+  const showServiceModal = useStore((s) => s.showServiceModal);
+  const showEndpointModal = useStore((s) => s.showEndpointModal);
+  const showDeleteModal = useStore((s) => s.showDeleteModal);
+  const showMigrateModal = useStore((s) => s.showMigrateModal);
+  const deleteTarget = useStore((s) => s.deleteTarget);
+  const migrateService = useStore((s) => s.migrateService);
+  const openServiceModal = useStore((s) => s.openServiceModal);
+  const openEndpointModal = useStore((s) => s.openEndpointModal);
+  const openDeleteModal = useStore((s) => s.openDeleteModal);
+  const openMigrateModal = useStore((s) => s.openMigrateModal);
+  const closeModals = useStore((s) => s.closeModals);
+  const projectID = useStore((s) => s.globalAPI.projectID);
+
+  const handleRowClick = (id: string) => {
+    const currentPath = location.pathname;
+    if (currentPath === `/services/${id}`) {
+      navigate("/services");
+    } else {
+      navigate(`/services/${id}`);
+    }
+  };
+
+  // Filter state
+  const [nameFilter, setNameFilter] = useState("");
+  const [visibilityFilter, setVisibilityFilter] = useState<string>("");
+  const [providerFilter, setProviderFilter] = useState<string>("");
+  const [enabledFilter, setEnabledFilter] = useState<string>("");
+  const [cascadeDelete, setCascadeDelete] = useState(false);
+
+  // Sort state
+  const [sortField, setSortField] = useState<SortField | null>(null);
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+
+  const services = data?.items ?? [];
+
+  useStatusChangeToast(services, "service");
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDir(sortDir === "asc" ? "desc" : "asc");
+    } else {
+      setSortField(field);
+      setSortDir("asc");
+    }
+  };
+
+  const filteredAndSortedServices = useMemo(() => {
+    let result = services.filter((s) => {
+      if (
+        nameFilter &&
+        !(
+          s.name?.toLowerCase().includes(nameFilter.toLowerCase()) ||
+          s.id.toLowerCase().includes(nameFilter.toLowerCase())
+        )
+      ) {
+        return false;
+      }
+      if (visibilityFilter && s.visibility !== visibilityFilter) return false;
+      if (providerFilter && s.provider !== providerFilter) return false;
+      if (enabledFilter && (s.enabled ? "yes" : "no") !== enabledFilter) return false;
+      return true;
+    });
+
+    if (sortField) {
+      result = [...result].sort((a, b) => {
+        let aVal: string | boolean | null = "";
+        let bVal: string | boolean | null = "";
+
+        switch (sortField) {
+          case "name":
+            aVal = a.name || "";
+            bVal = b.name || "";
+            break;
+          case "status":
+            aVal = a.status;
+            bVal = b.status;
+            break;
+          case "health_status":
+            aVal = a.health_status;
+            bVal = b.health_status;
+            break;
+          case "visibility":
+            aVal = a.visibility;
+            bVal = b.visibility;
+            break;
+          case "provider":
+            aVal = a.provider;
+            bVal = b.provider;
+            break;
+          case "enabled":
+            aVal = a.enabled;
+            bVal = b.enabled;
+            break;
+        }
+
+        if (typeof aVal === "boolean") {
+          return sortDir === "asc" ? (aVal === bVal ? 0 : aVal ? -1 : 1) : aVal === bVal ? 0 : aVal ? 1 : -1;
+        }
+
+        const cmp = String(aVal || "").localeCompare(String(bVal || ""));
+        return sortDir === "asc" ? cmp : -cmp;
+      });
+    }
+
+    return result;
+  }, [services, nameFilter, visibilityFilter, providerFilter, enabledFilter, sortField, sortDir]);
+
+  const handleDelete = async (cascade?: boolean) => {
+    if (deleteTarget?.type === "service") {
+      try {
+        await deleteService.mutateAsync({ id: deleteTarget.item.id, cascade });
+        closeModals();
+        setCascadeDelete(false);
+      } catch {
+        // Error is captured in deleteService.error, displayed by DeleteModal
+      }
+    }
+  };
+
+  const clearFilters = () => {
+    setNameFilter("");
+    setVisibilityFilter("");
+    setProviderFilter("");
+    setEnabledFilter("");
+  };
+
+  const hasFilters = nameFilter || visibilityFilter || providerFilter || enabledFilter;
+
+  if (isLoading) return <LoadingIndicator className="m-auto" />;
+  if (error) return <Message variant="danger">{error.message}</Message>;
+
+  return (
+    <>
+      <Stack direction="vertical" gap="4">
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: "1rem",
+            flexWrap: "wrap",
+          }}
+        >
+          <div
+            style={{ display: "flex", flexDirection: "row", alignItems: "center", gap: "0.75rem", flexWrap: "wrap" }}
+          >
+            <div style={{ width: "14rem" }}>
+              <TextInput
+                placeholder="Filter by name or ID..."
+                value={nameFilter}
+                onChange={(e) => setNameFilter(e.target.value)}
+              />
+            </div>
+            <div style={{ width: "8rem" }}>
+              <Select
+                value={visibilityFilter}
+                onChange={(v) => setVisibilityFilter(String(v ?? ""))}
+                placeholder="Visibility"
+              >
+                <SelectOption value="private">Private</SelectOption>
+                <SelectOption value="public">Public</SelectOption>
+              </Select>
+            </div>
+            <div style={{ width: "9rem" }}>
+              <Select
+                value={providerFilter}
+                onChange={(v) => setProviderFilter(String(v ?? ""))}
+                placeholder="Provider"
+              >
+                <SelectOption value="tenant">Tenant</SelectOption>
+                <SelectOption value="cp">Control Plane</SelectOption>
+              </Select>
+            </div>
+            <div style={{ width: "8rem" }}>
+              <Select value={enabledFilter} onChange={(v) => setEnabledFilter(String(v ?? ""))} placeholder="Enabled">
+                <SelectOption value="yes">Yes</SelectOption>
+                <SelectOption value="no">No</SelectOption>
+              </Select>
+            </div>
+            {hasFilters && (
+              <Button variant="subdued" onClick={clearFilters}>
+                Clear Filters
+              </Button>
+            )}
+          </div>
+          {canEdit && (
+            <Stack gap="2">
+              {cloudAdmin ? (
+                <Button icon="addCircle" variant="primary-danger" onClick={() => openServiceModal(null, "cp")}>
+                  Create CP Service
+                </Button>
+              ) : (
+                <Button icon="addCircle" onClick={() => openServiceModal()}>
+                  Create Service
+                </Button>
+              )}
+            </Stack>
+          )}
+        </div>
+
+        <DataGrid columns={canEdit ? 8 : 7}>
+          <DataGridRow>
+            <SortableHeader label="Name" field="name" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
+            <SortableHeader
+              label="Provider"
+              field="provider"
+              sortField={sortField}
+              sortDir={sortDir}
+              onSort={handleSort}
+            />
+            <SortableHeader label="Status" field="status" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
+            <SortableHeader
+              label="Health"
+              field="health_status"
+              sortField={sortField}
+              sortDir={sortDir}
+              onSort={handleSort}
+            />
+            <SortableHeader
+              label="Visibility"
+              field="visibility"
+              sortField={sortField}
+              sortDir={sortDir}
+              onSort={handleSort}
+            />
+            <DataGridHeadCell>Ports</DataGridHeadCell>
+            <SortableHeader
+              label="Enabled"
+              field="enabled"
+              sortField={sortField}
+              sortDir={sortDir}
+              onSort={handleSort}
+            />
+            {canEdit && <DataGridHeadCell>Actions</DataGridHeadCell>}
+          </DataGridRow>
+          {filteredAndSortedServices.map((s) => {
+            const isExternal = projectID && s.project_id !== projectID;
+            return (
+              <DataGridRow
+                key={s.id}
+                onClick={() => handleRowClick(s.id)}
+                className={`cursor-pointer hover:bg-theme-background-lvl-2 ${!s.enabled ? "bg-theme-background-lvl-3 opacity-60" : ""} ${isExternal ? "border-l-4 border-l-theme-warning" : ""}`}
+              >
+                <DataGridCell>
+                  <div className="flex flex-col max-w-72">
+                    <div className="flex items-center gap-2">
+                      <span className="font-semibold truncate" title={s.name || "Unnamed"}>
+                        {s.name || "Unnamed"}
+                      </span>
+                      {isExternal && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Badge text="External" />
+                          </TooltipTrigger>
+                          <TooltipContent>Service belongs to project {s.project_id}</TooltipContent>
+                        </Tooltip>
+                      )}
+                    </div>
+                    <span className="text-xs text-theme-light">{s.id}</span>
+                  </div>
+                </DataGridCell>
+                <DataGridCell>
+                  <ProviderLabel provider={s.provider} />
+                </DataGridCell>
+                <DataGridCell>
+                  <StatusBadge status={s.status} />
+                </DataGridCell>
+                <DataGridCell>
+                  <StatusBadge status={s.health_status} />
+                </DataGridCell>
+                <DataGridCell>{s.visibility}</DataGridCell>
+                <DataGridCell>
+                  {(() => {
+                    const portsStr = formatPorts(s.ports);
+                    if (portsStr.length > 30) {
+                      return (
+                        <Tooltip>
+                          <TooltipTrigger>
+                            <span className="truncate max-w-32 block">{portsStr}</span>
+                          </TooltipTrigger>
+                          <TooltipContent>{portsStr}</TooltipContent>
+                        </Tooltip>
+                      );
+                    }
+                    return portsStr;
+                  })()}
+                </DataGridCell>
+                <DataGridCell>
+                  <EnabledIcon enabled={s.enabled} />
+                </DataGridCell>
+                {canEdit && (
+                  <DataGridCell>
+                    <Stack gap="1">
+                      {!cloudAdmin && (
+                        <Button
+                          size="small"
+                          icon="place"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            openEndpointModal(null, s.id);
+                          }}
+                          title="Create Endpoint"
+                        />
+                      )}
+                      {(!isExternal || cloudAdmin) && (
+                        <>
+                          <Button
+                            size="small"
+                            icon="edit"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              openServiceModal(s);
+                            }}
+                          />
+                          <Button
+                            size="small"
+                            icon="deleteForever"
+                            variant="primary-danger"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              openDeleteModal({ type: "service", item: s });
+                            }}
+                          />
+                        </>
+                      )}
+                      {cloudAdmin && (
+                        <Button
+                          size="small"
+                          icon="upload"
+                          variant="primary-danger"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            openMigrateModal(s);
+                          }}
+                          title="Migrate Service"
+                        />
+                      )}
+                    </Stack>
+                  </DataGridCell>
+                )}
+              </DataGridRow>
+            );
+          })}
+        </DataGrid>
+
+        {filteredAndSortedServices.length === 0 && services.length > 0 && (
+          <Message variant="info">No services match your filters.</Message>
+        )}
+        {services.length === 0 && <Message variant="info">No services found.</Message>}
+      </Stack>
+
+      <Routes>
+        <Route path=":serviceId/*" element={<ServiceDetail canEdit={canEdit} />} />
+      </Routes>
+
+      {showServiceModal && <ServiceForm />}
+      {showEndpointModal && <EndpointForm />}
+      {showDeleteModal && deleteTarget?.type === "service" && (
+        <DeleteModal
+          onConfirm={handleDelete}
+          isLoading={deleteService.isPending}
+          error={deleteService.error}
+          cascade={cascadeDelete}
+          onCascadeChange={setCascadeDelete}
+        />
+      )}
+      {showMigrateModal && migrateService && <MigrateModal service={migrateService} onClose={closeModals} />}
+    </>
+  );
+};

--- a/web/src/components/ServicePicker.tsx
+++ b/web/src/components/ServicePicker.tsx
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { PopupPicker } from "./shared/PopupPicker";
+import { useServices } from "../api";
+import type { Service } from "../types";
+
+interface ServicePickerProps {
+  onSelect: (service: Service) => void;
+  disabled?: boolean;
+}
+
+export const ServicePicker = ({ onSelect, disabled }: ServicePickerProps) => {
+  const { data, isLoading, error } = useServices();
+
+  return (
+    <PopupPicker
+      items={data?.items ?? []}
+      isLoading={isLoading}
+      error={error}
+      onSelect={onSelect}
+      disabled={disabled}
+      title="Browse services"
+      filterPlaceholder="Filter by name or ID..."
+      emptyMessage="No services found"
+      errorMessage="Failed to load services"
+    />
+  );
+};

--- a/web/src/components/StatusBadge.tsx
+++ b/web/src/components/StatusBadge.tsx
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { Badge } from "@cloudoperators/juno-ui-components";
+import type { ServiceStatus, EndpointStatus, HealthStatus } from "../types";
+
+type Status = ServiceStatus | EndpointStatus | HealthStatus;
+type BadgeVariant = "success" | "info" | "warning" | "danger" | "default";
+
+const COLORS: Record<string, BadgeVariant> = {
+  AVAILABLE: "success",
+  ONLINE: "success",
+  PENDING_CREATE: "info",
+  PENDING_UPDATE: "info",
+  PENDING_APPROVAL: "warning",
+  PENDING_DELETE: "info",
+  PENDING_REJECTED: "info",
+  DEGRADED: "warning",
+  REJECTED: "danger",
+  FAILED: "danger",
+  OFFLINE: "danger",
+  ERROR_QUOTA: "danger",
+  UNAVAILABLE: "default",
+  UNCHECKED: "default",
+};
+
+const PENDING_STATUSES = ["PENDING_CREATE", "PENDING_UPDATE", "PENDING_DELETE", "PENDING_REJECTED"];
+
+export const StatusBadge = ({ status }: { status: Status | null | undefined }) => {
+  if (!status) return null;
+  const isPending = PENDING_STATUSES.includes(status);
+
+  return (
+    <Badge
+      variant={COLORS[status] ?? "default"}
+      style={isPending ? { animation: "pulse-pending-info 2s ease-in-out infinite" } : undefined}
+    >
+      {status}
+    </Badge>
+  );
+};

--- a/web/src/components/SubnetPicker.tsx
+++ b/web/src/components/SubnetPicker.tsx
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState } from "react";
+import { PopupPicker } from "./shared/PopupPicker";
+import { useSubnets } from "../api";
+import type { Subnet } from "../types";
+
+interface SubnetPickerProps {
+  onSelect: (subnet: Subnet) => void;
+  disabled?: boolean;
+}
+
+export const SubnetPicker = ({ onSelect, disabled }: SubnetPickerProps) => {
+  const [fetchEnabled, setFetchEnabled] = useState(false);
+  const { data, isLoading, error } = useSubnets(fetchEnabled);
+
+  return (
+    <PopupPicker
+      items={data?.subnets ?? []}
+      isLoading={isLoading}
+      error={error}
+      onSelect={onSelect}
+      onOpen={() => setFetchEnabled(true)}
+      disabled={disabled}
+      title="Browse subnets"
+      filterPlaceholder="Filter by name, ID, or CIDR..."
+      emptyMessage="No subnets found"
+      errorMessage="Failed to load subnets"
+      renderItem={(subnet) => (
+        <div className="flex flex-col items-start gap-0.5">
+          <span className="font-medium">{subnet.name || "(unnamed)"}</span>
+          <span className="text-xs text-theme-light font-mono">{subnet.cidr}</span>
+          <span className="text-xs text-theme-light font-mono">{subnet.id}</span>
+        </div>
+      )}
+      filterFn={(subnet, search) =>
+        (subnet.name?.toLowerCase().includes(search.toLowerCase()) ?? false) ||
+        subnet.id.toLowerCase().includes(search.toLowerCase()) ||
+        subnet.cidr.toLowerCase().includes(search.toLowerCase())
+      }
+    />
+  );
+};

--- a/web/src/components/shared/PopupPicker.tsx
+++ b/web/src/components/shared/PopupPicker.tsx
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState, ReactNode } from "react";
+import {
+  PopupMenu,
+  PopupMenuToggle,
+  PopupMenuOptions,
+  PopupMenuItem,
+  Button,
+  TextInput,
+  Spinner,
+  Icon,
+} from "@cloudoperators/juno-ui-components";
+
+interface PopupPickerItem {
+  id: string;
+  name?: string | null;
+}
+
+interface PopupPickerProps<T extends PopupPickerItem> {
+  items: T[];
+  isLoading?: boolean;
+  error?: Error | null;
+  onSelect: (item: T) => void;
+  onOpen?: () => void;
+  disabled?: boolean;
+  title?: string;
+  filterPlaceholder?: string;
+  emptyMessage?: string;
+  errorMessage?: string;
+  renderItem?: (item: T) => ReactNode;
+  filterFn?: (item: T, search: string) => boolean;
+}
+
+export function PopupPicker<T extends PopupPickerItem>({
+  items,
+  isLoading = false,
+  error = null,
+  onSelect,
+  onOpen,
+  disabled = false,
+  title = "Browse",
+  filterPlaceholder = "Filter by name or ID...",
+  emptyMessage = "No items found",
+  errorMessage = "Failed to load items",
+  renderItem,
+  filterFn,
+}: PopupPickerProps<T>) {
+  const [search, setSearch] = useState("");
+
+  const defaultFilter = (item: T, s: string) =>
+    (item.name?.toLowerCase().includes(s.toLowerCase()) ?? false) || item.id.toLowerCase().includes(s.toLowerCase());
+
+  const filtered = items.filter((item) => (filterFn ? filterFn(item, search) : defaultFilter(item, search)));
+
+  const handleClose = () => {
+    setSearch("");
+  };
+
+  const handleSelect = (item: T) => {
+    onSelect(item);
+    setSearch("");
+  };
+
+  const defaultRenderItem = (item: T) => (
+    <div className="flex flex-col items-start gap-0.5">
+      <span className="font-medium">{item.name || "(unnamed)"}</span>
+      <span className="text-xs text-theme-light font-mono">{item.id}</span>
+    </div>
+  );
+
+  return (
+    <PopupMenu onOpen={onOpen} onClose={handleClose} disabled={disabled}>
+      <PopupMenuToggle>
+        <Button variant="subdued" title={title} disabled={disabled} className="h-[2.375rem]">
+          <Icon icon="search" size="18" />
+        </Button>
+      </PopupMenuToggle>
+      <PopupMenuOptions className="w-96">
+        <div className="p-2 border-b border-theme-background-lvl-3">
+          <TextInput
+            placeholder={filterPlaceholder}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            autoFocus
+          />
+        </div>
+
+        <div className="max-h-64 overflow-auto">
+          {isLoading && (
+            <div className="flex justify-center py-4">
+              <Spinner />
+            </div>
+          )}
+
+          {error && <div className="p-3 text-sm text-theme-danger">{errorMessage}</div>}
+
+          {!isLoading && !error && filtered.length === 0 && (
+            <div className="p-3 text-sm text-theme-light">{emptyMessage}</div>
+          )}
+
+          {!isLoading &&
+            !error &&
+            filtered.map((item) => (
+              <PopupMenuItem key={item.id} onClick={() => handleSelect(item)}>
+                {renderItem ? renderItem(item) : defaultRenderItem(item)}
+              </PopupMenuItem>
+            ))}
+        </div>
+      </PopupMenuOptions>
+    </PopupMenu>
+  );
+}

--- a/web/src/hooks/useStatusChangeToast.ts
+++ b/web/src/hooks/useStatusChangeToast.ts
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { useRef, useEffect } from "react";
+import { useStore } from "../store";
+import type { ServiceStatus, EndpointStatus } from "../types";
+
+type Status = ServiceStatus | EndpointStatus;
+type ItemType = "service" | "endpoint";
+
+interface TrackedItem {
+  id: string;
+  name: string | null;
+  status: Status;
+  created_at: string;
+  updated_at: string;
+}
+
+interface TrackedState {
+  name: string | null;
+  status: Status;
+  pendingSince: number; // timestamp when item entered pending state
+}
+
+const PENDING_STATUSES: Status[] = [
+  "PENDING_CREATE",
+  "PENDING_UPDATE",
+  "PENDING_DELETE",
+  "PENDING_APPROVAL",
+  "PENDING_REJECTED",
+];
+
+const isPending = (status: Status): boolean => PENDING_STATUSES.includes(status);
+
+const getToastVariant = (status: Status | "DELETED"): "success" | "warning" | "danger" => {
+  switch (status) {
+    case "AVAILABLE":
+    case "DELETED":
+      return "success";
+    case "UNAVAILABLE":
+      return "warning";
+    case "REJECTED":
+    case "FAILED":
+    case "ERROR_QUOTA":
+      return "danger";
+    default:
+      return "success";
+  }
+};
+
+const formatDuration = (ms: number): string => {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m`;
+};
+
+const getToastMessage = (
+  type: ItemType,
+  name: string | null,
+  status: Status | "DELETED",
+  durationMs: number | null
+): string => {
+  const typeLabel = type.charAt(0).toUpperCase() + type.slice(1);
+  const displayName = name ? `${typeLabel} "${name}"` : typeLabel;
+  const duration = durationMs !== null ? ` (${formatDuration(durationMs)})` : "";
+
+  switch (status) {
+    case "AVAILABLE":
+      return `${displayName} is now available${duration}`;
+    case "DELETED":
+      return `${displayName} was deleted${duration}`;
+    case "REJECTED":
+      return `${displayName} was rejected${duration}`;
+    case "FAILED":
+      return `${displayName} failed${duration}`;
+    case "ERROR_QUOTA":
+      return `${displayName} hit quota limit${duration}`;
+    case "UNAVAILABLE":
+      return `${displayName} is unavailable${duration}`;
+    default:
+      return `${displayName} status changed to ${status}${duration}`;
+  }
+};
+
+export const useStatusChangeToast = <T extends TrackedItem>(items: T[], type: ItemType) => {
+  const trackedRef = useRef<Map<string, TrackedState>>(new Map());
+  const addToast = useStore((s) => s.addToast);
+
+  useEffect(() => {
+    const tracked = trackedRef.current;
+    const currentIds = new Set(items.map((i) => i.id));
+
+    // Check for items that disappeared while in PENDING_DELETE
+    for (const [id, state] of tracked) {
+      if (!currentIds.has(id) && state.status === "PENDING_DELETE") {
+        const durationMs = state.pendingSince > 0 ? Date.now() - state.pendingSince : null;
+        addToast({
+          variant: getToastVariant("DELETED"),
+          message: getToastMessage(type, state.name, "DELETED", durationMs),
+        });
+        tracked.delete(id);
+      } else if (!currentIds.has(id)) {
+        // Item disappeared but wasn't in PENDING_DELETE - just clean up
+        tracked.delete(id);
+      }
+    }
+
+    for (const item of items) {
+      const prev = tracked.get(item.id);
+      const curr = item.status;
+      const currIsPending = isPending(curr);
+
+      if (!prev) {
+        // First time seeing this item
+        tracked.set(item.id, {
+          name: item.name,
+          status: curr,
+          pendingSince: currIsPending ? new Date(item.updated_at).getTime() : 0,
+        });
+        continue;
+      }
+
+      const prevIsPending = isPending(prev.status);
+
+      // Transition: non-pending -> pending (start tracking duration)
+      if (!prevIsPending && currIsPending) {
+        tracked.set(item.id, {
+          name: item.name,
+          status: curr,
+          pendingSince: new Date(item.updated_at).getTime(),
+        });
+        continue;
+      }
+
+      // Transition: pending -> non-pending (show toast with duration)
+      if (prevIsPending && !currIsPending) {
+        const durationMs = prev.pendingSince > 0 ? Date.now() - prev.pendingSince : null;
+        addToast({
+          variant: getToastVariant(curr),
+          message: getToastMessage(type, item.name, curr, durationMs),
+        });
+        tracked.set(item.id, {
+          name: item.name,
+          status: curr,
+          pendingSince: 0,
+        });
+        continue;
+      }
+
+      // Status changed but still in same category (pending or non-pending)
+      if (prev.status !== curr) {
+        tracked.set(item.id, {
+          name: item.name,
+          status: curr,
+          pendingSince: currIsPending ? prev.pendingSince : 0,
+        });
+      }
+    }
+  }, [items, type, addToast]);
+};

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRoot, Root } from "react-dom/client";
+import { createElement } from "react";
+import type { AppProps } from "./types";
+
+let root: Root | null = null;
+
+export const mount = async (container: HTMLElement, options: { props?: AppProps } = {}) => {
+  const props = options.props || {};
+
+  // Enable mocking if requested
+  if (props.mockAPI) {
+    const { startMocking } = await import("./mocks/browser");
+    const endpoint = props.endpoint || `https://${window.location.host}`;
+    await startMocking(endpoint);
+  }
+
+  // Load and render app
+  const { default: App } = await import("./App");
+  root = createRoot(container);
+  root.render(createElement(App, { ...props, endpoint: props.endpoint || `https://${window.location.host}` }));
+};
+
+export const unmount = () => root?.unmount();

--- a/web/src/mocks/browser.ts
+++ b/web/src/mocks/browser.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { setupWorker } from "msw/browser";
+import { createHandlers } from "./handlers";
+
+export const startMocking = async (endpoint: string) => {
+  const worker = setupWorker(...createHandlers(endpoint));
+  await worker.start({ onUnhandledRequest: "bypass" });
+  return worker;
+};

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -1,0 +1,1188 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { http, HttpResponse } from "msw";
+import type { Service, Endpoint, EndpointConsumer, RBACPolicy, Network, Subnet, Port, Agent } from "../types";
+
+// Project IDs for different tenants (32-char hex, no dashes - OpenStack format)
+const OWN_PROJECT = "e9141fb24eee4b3e9f25ae69cda31132";
+const FINANCE_PROJECT = "d0e1f2a3b4c54d6e8f8a9b0c1d2e3f4a";
+const ANALYTICS_PROJECT = "e1f2a3b4c5d64e7f8a9b0c1d2e3f4a5b";
+const DEVOPS_PROJECT = "f2a3b4c5d6e74f8a9b0c1d2e3f4a5b6c";
+
+// Network IDs (UUIDv4)
+const NET_PRODUCTION = "11110001-aaaa-4bbb-8ccc-ddddeeee0001";
+const NET_STAGING = "22220002-bbbb-4ccc-8ddd-eeeeffff0002";
+const NET_DEVELOPMENT = "33330003-cccc-4ddd-8eee-ffffaaaa0003";
+const NET_SHARED = "44440004-dddd-4eee-8fff-aaaabbbb0004";
+const NET_ANALYTICS = "55550005-eeee-4fff-8aaa-bbbbcccc0005";
+
+// Service IDs (UUIDv4)
+const SVC_POSTGRES = "a1b2c3d4-e5f6-4890-abcd-ef1234567890";
+const SVC_REDIS = "b2c3d4e5-f6a7-4901-bcde-f12345678901";
+const SVC_KAFKA = "c3d4e5f6-a7b8-4012-cdef-123456789012";
+const SVC_ELASTICSEARCH = "d4e5f6a7-b8c9-4123-def0-234567890123";
+const SVC_GRAFANA = "e5f6a7b8-c9d0-4234-ef01-345678901234";
+const SVC_CP_APIGW = "f6a7b8c9-d0e1-4345-f012-456789012345";
+const SVC_CP_IDENTITY = "a7b8c9d0-e1f2-4456-0123-567890123456";
+const SVC_CP_LOGGING = "b8c9d0e1-f2a3-4567-1234-678901234567";
+const SVC_FINANCE_DB = "c9d0e1f2-a3b4-4678-2345-789012345678";
+const SVC_FINANCE_API = "d0e1f2a3-b4c5-4789-3456-890123456789";
+const SVC_SPARK = "e1f2a3b4-c5d6-4890-4567-901234567890";
+const SVC_AIRFLOW = "f2a3b4c5-d6e7-4901-5678-012345678901";
+const SVC_ML = "a3b4c5d6-e7f8-4012-6789-123456789012";
+const SVC_JENKINS = "b4c5d6e7-f8a9-4123-7890-234567890123";
+const SVC_REGISTRY = "c5d6e7f8-a9b0-4234-8901-345678901234";
+const SVC_VAULT = "d6e7f8a9-b0c1-4345-9012-456789012345";
+const SVC_EDGE = "e7f8a9b0-c1d2-4456-0123-567890123456";
+
+// Endpoint IDs (UUIDv4)
+const EP_OWN_POSTGRES_1 = "11111111-1111-4111-8111-111111111111";
+const EP_OWN_POSTGRES_2 = "22222222-2222-4222-8222-222222222222";
+const EP_OWN_POSTGRES_3 = "33333333-3333-4333-8333-333333333333";
+const EP_OWN_REDIS_1 = "44444444-4444-4444-8444-444444444444";
+const EP_OWN_REDIS_2 = "55555555-5555-4555-8555-555555555555";
+const EP_OWN_KAFKA_1 = "66666666-6666-4666-8666-666666666666";
+const EP_OWN_APIGW_1 = "77777777-7777-4777-8777-777777777777";
+const EP_OWN_IDENTITY_1 = "88888888-8888-4888-8888-888888888888";
+const EP_OWN_LOGGING_1 = "99999999-9999-4999-8999-999999999999";
+const EP_OWN_FINANCE_1 = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const EP_OWN_SPARK_1 = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const EP_OWN_VAULT_1 = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const EP_OWN_REGISTRY_1 = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+const EP_FINANCE_POSTGRES_1 = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+const EP_ANALYTICS_KAFKA_1 = "ffffffff-ffff-4fff-8fff-ffffffffffff";
+const EP_DEVOPS_ES_1 = "00000001-0001-4001-8001-000000000001";
+const EP_DEVOPS_GRAFANA_1 = "00000002-0002-4002-8002-000000000002";
+
+// Subnet IDs (UUIDv4)
+const SUBNET_PRODUCTION = "aaa00001-0001-4001-8001-000000000001";
+const SUBNET_STAGING = "aaa00002-0002-4002-8002-000000000002";
+const SUBNET_DEVELOPMENT = "aaa00003-0003-4003-8003-000000000003";
+const SUBNET_SHARED = "aaa00004-0004-4004-8004-000000000004";
+const SUBNET_ANALYTICS = "aaa00005-0005-4005-8005-000000000005";
+const SUBNET_BACKUP = "aaa00006-0006-4006-8006-000000000006";
+
+// Additional Network IDs (UUIDv4)
+const NET_BACKUP = "66660006-ffff-4aaa-8bbb-ccccdddd0006";
+const NET_DMZ = "77770007-aaaa-4bbb-8ccc-ddddeeee0007";
+const NET_INTERNAL = "88880008-bbbb-4ccc-8ddd-eeeeffff0008";
+
+// Port IDs (UUIDv4)
+const PORT_PROD_WEB = "bbb00001-0001-4001-8001-000000000001";
+const PORT_PROD_DB = "bbb00002-0002-4002-8002-000000000002";
+const PORT_STAGING_APP = "bbb00003-0003-4003-8003-000000000003";
+const PORT_DEV_TEST = "bbb00004-0004-4004-8004-000000000004";
+const PORT_SHARED_LB = "bbb00005-0005-4005-8005-000000000005";
+const PORT_RESERVED = "bbb00006-0006-4006-8006-000000000006";
+
+const services: Service[] = [
+  // === OWN PROJECT SERVICES ===
+  {
+    id: SVC_POSTGRES,
+    name: "PostgreSQL Primary",
+    description: "Primary PostgreSQL database cluster",
+    enabled: true,
+    ports: [5432],
+    network_id: NET_PRODUCTION,
+    ip_addresses: ["10.0.1.10"],
+    status: "AVAILABLE",
+    require_approval: true,
+    visibility: "private",
+    availability_zone: "eu-de-1a",
+    proxy_protocol: true,
+    connection_mirroring: false,
+    protocol: "TCP",
+    provider: "tenant",
+    tags: ["database", "production"],
+    health_status: "ONLINE",
+    host: "db-primary.example.com",
+    project_id: OWN_PROJECT,
+    created_at: "2024-01-15T10:30:00Z",
+    updated_at: "2024-01-20T14:45:00Z",
+  },
+  {
+    id: SVC_REDIS,
+    name: "Redis Cache",
+    description: "Distributed Redis cache cluster",
+    enabled: true,
+    ports: [6379],
+    network_id: NET_PRODUCTION,
+    ip_addresses: ["10.0.1.20"],
+    status: "AVAILABLE",
+    require_approval: false,
+    visibility: "private",
+    availability_zone: "eu-de-1a",
+    proxy_protocol: false,
+    connection_mirroring: false,
+    protocol: "TCP",
+    provider: "tenant",
+    tags: ["cache", "production"],
+    health_status: "ONLINE",
+    host: "redis.example.com",
+    project_id: OWN_PROJECT,
+    created_at: "2024-02-01T08:00:00Z",
+    updated_at: "2024-02-10T12:30:00Z",
+  },
+  {
+    id: SVC_KAFKA,
+    name: "Kafka Broker",
+    description: "Message streaming platform",
+    enabled: true,
+    ports: [9092, 9093],
+    network_id: NET_PRODUCTION,
+    ip_addresses: ["10.0.1.30"],
+    status: "AVAILABLE",
+    require_approval: true,
+    visibility: "private",
+    availability_zone: "eu-de-1b",
+    proxy_protocol: false,
+    connection_mirroring: false,
+    protocol: "TCP",
+    provider: "tenant",
+    tags: ["messaging", "production"],
+    health_status: "ONLINE",
+    host: "kafka.example.com",
+    project_id: OWN_PROJECT,
+    created_at: "2024-03-01T09:00:00Z",
+    updated_at: "2024-03-15T11:00:00Z",
+  },
+  {
+    id: SVC_ELASTICSEARCH,
+    name: "Elasticsearch",
+    description: "Search and analytics engine",
+    enabled: true,
+    ports: [9200, 9300],
+    network_id: NET_STAGING,
+    ip_addresses: ["10.0.2.10"],
+    status: "PENDING_UPDATE",
+    require_approval: false,
+    visibility: "private",
+    availability_zone: "eu-de-1a",
+    proxy_protocol: false,
+    connection_mirroring: false,
+    protocol: "HTTP",
+    provider: "tenant",
+    tags: ["search", "staging"],
+    health_status: "DEGRADED",
+    host: "es.example.com",
+    project_id: OWN_PROJECT,
+    created_at: "2024-04-01T10:00:00Z",
+    updated_at: "2024-04-10T12:00:00Z",
+  },
+  {
+    id: SVC_GRAFANA,
+    name: "Grafana Monitoring",
+    description: "Observability dashboards",
+    enabled: true,
+    ports: [3000],
+    network_id: NET_SHARED,
+    ip_addresses: ["10.0.3.10"],
+    status: "AVAILABLE",
+    require_approval: false,
+    visibility: "public",
+    availability_zone: "eu-de-1c",
+    proxy_protocol: false,
+    connection_mirroring: false,
+    protocol: "HTTP",
+    provider: "tenant",
+    tags: ["monitoring", "observability"],
+    health_status: "ONLINE",
+    host: "grafana.example.com",
+    project_id: OWN_PROJECT,
+    created_at: "2024-05-01T08:00:00Z",
+    updated_at: "2024-05-15T10:00:00Z",
+  },
+
+  // === MANAGED (CONTROL PLANE) SERVICES ===
+  {
+    id: SVC_CP_APIGW,
+    name: "API Gateway",
+    description: "Central API gateway managed by control plane",
+    enabled: true,
+    ports: [443, 8443],
+    network_id: NET_SHARED,
+    ip_addresses: ["10.100.0.10"],
+    status: "AVAILABLE",
+    require_approval: false,
+    visibility: "public",
+    availability_zone: "eu-de-1a",
+    proxy_protocol: false,
+    connection_mirroring: false,
+    protocol: "HTTP",
+    provider: "cp",
+    tags: ["api", "managed"],
+    health_status: "ONLINE",
+    host: "api-gw.cp.example.com",
+    project_id: OWN_PROJECT,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-06-01T00:00:00Z",
+  },
+  {
+    id: SVC_CP_IDENTITY,
+    name: "Identity Service",
+    description: "Centralized authentication and authorization",
+    enabled: true,
+    ports: [443],
+    network_id: NET_SHARED,
+    ip_addresses: ["10.100.0.20"],
+    status: "AVAILABLE",
+    require_approval: false,
+    visibility: "public",
+    availability_zone: "eu-de-1a",
+    proxy_protocol: false,
+    connection_mirroring: false,
+    protocol: "HTTP",
+    provider: "cp",
+    tags: ["auth", "managed"],
+    health_status: "ONLINE",
+    host: "identity.cp.example.com",
+    project_id: OWN_PROJECT,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-06-01T00:00:00Z",
+  },
+  {
+    id: SVC_CP_LOGGING,
+    name: "Logging Service",
+    description: "Centralized log aggregation",
+    enabled: true,
+    ports: [5044, 8080],
+    network_id: NET_SHARED,
+    ip_addresses: ["10.100.0.30"],
+    status: "PENDING_UPDATE",
+    require_approval: false,
+    visibility: "private",
+    availability_zone: "eu-de-1b",
+    proxy_protocol: false,
+    connection_mirroring: false,
+    protocol: "TCP",
+    provider: "cp",
+    tags: ["logging", "managed"],
+    health_status: "DEGRADED",
+    host: "logging.cp.example.com",
+    project_id: OWN_PROJECT,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-06-10T00:00:00Z",
+  },
+
+  // === EXTERNAL PROJECT: FINANCE ===
+  {
+    id: SVC_FINANCE_DB,
+    name: "Finance DB",
+    description: "Financial data warehouse",
+    enabled: true,
+    ports: [5432],
+    network_id: NET_ANALYTICS,
+    ip_addresses: ["10.200.1.10"],
+    status: "AVAILABLE",
+    require_approval: true,
+    visibility: "private",
+    availability_zone: "eu-de-1a",
+    proxy_protocol: true,
+    connection_mirroring: false,
+    protocol: "TCP",
+    provider: "tenant",
+    tags: ["finance", "database"],
+    health_status: "ONLINE",
+    host: "finance-db.example.com",
+    project_id: FINANCE_PROJECT,
+    created_at: "2024-02-01T00:00:00Z",
+    updated_at: "2024-06-01T00:00:00Z",
+  },
+  {
+    id: SVC_FINANCE_API,
+    name: "Finance API",
+    description: "Financial reporting API",
+    enabled: true,
+    ports: [443],
+    network_id: NET_ANALYTICS,
+    ip_addresses: ["10.200.1.20"],
+    status: "AVAILABLE",
+    require_approval: true,
+    visibility: "private",
+    availability_zone: "eu-de-1b",
+    proxy_protocol: false,
+    connection_mirroring: false,
+    protocol: "HTTP",
+    provider: "tenant",
+    tags: ["finance", "api"],
+    health_status: "ONLINE",
+    host: "finance-api.example.com",
+    project_id: FINANCE_PROJECT,
+    created_at: "2024-02-15T00:00:00Z",
+    updated_at: "2024-06-01T00:00:00Z",
+  },
+
+  // === EXTERNAL PROJECT: ANALYTICS ===
+  {
+    id: SVC_SPARK,
+    name: "Spark Cluster",
+    description: "Apache Spark processing cluster",
+    enabled: true,
+    ports: [7077, 8080, 4040],
+    network_id: NET_ANALYTICS,
+    ip_addresses: ["10.200.2.10", "10.200.2.11", "10.200.2.12"],
+    status: "AVAILABLE",
+    require_approval: false,
+    visibility: "private",
+    availability_zone: "eu-de-1a",
+    proxy_protocol: false,
+    connection_mirroring: false,
+    protocol: "TCP",
+    provider: "tenant",
+    tags: ["analytics", "spark"],
+    health_status: "ONLINE",
+    host: "spark.analytics.example.com",
+    project_id: ANALYTICS_PROJECT,
+    created_at: "2024-03-01T00:00:00Z",
+    updated_at: "2024-06-01T00:00:00Z",
+  },
+  {
+    id: SVC_AIRFLOW,
+    name: "Airflow",
+    description: "Workflow orchestration",
+    enabled: true,
+    ports: [8080],
+    network_id: NET_ANALYTICS,
+    ip_addresses: ["10.200.2.20"],
+    status: "PENDING_CREATE",
+    require_approval: false,
+    visibility: "private",
+    availability_zone: "eu-de-1b",
+    proxy_protocol: false,
+    connection_mirroring: false,
+    protocol: "HTTP",
+    provider: "tenant",
+    tags: ["analytics", "workflow"],
+    health_status: "UNCHECKED",
+    host: "airflow.analytics.example.com",
+    project_id: ANALYTICS_PROJECT,
+    created_at: "2024-06-01T00:00:00Z",
+    updated_at: "2024-06-01T00:00:00Z",
+  },
+  {
+    id: SVC_ML,
+    name: "ML Platform",
+    description: "Machine learning model serving",
+    enabled: true,
+    ports: [8501, 8500],
+    network_id: NET_ANALYTICS,
+    ip_addresses: ["10.200.2.30"],
+    status: "AVAILABLE",
+    require_approval: true,
+    visibility: "private",
+    availability_zone: "eu-de-1c",
+    proxy_protocol: false,
+    connection_mirroring: false,
+    protocol: "HTTP",
+    provider: "tenant",
+    tags: ["analytics", "ml"],
+    health_status: "ONLINE",
+    host: "ml.analytics.example.com",
+    project_id: ANALYTICS_PROJECT,
+    created_at: "2024-04-01T00:00:00Z",
+    updated_at: "2024-06-01T00:00:00Z",
+  },
+
+  // === EXTERNAL PROJECT: DEVOPS ===
+  {
+    id: SVC_JENKINS,
+    name: "Jenkins CI",
+    description: "Continuous integration server",
+    enabled: true,
+    ports: [8080, 50000],
+    network_id: NET_DEVELOPMENT,
+    ip_addresses: ["10.200.3.10"],
+    status: "AVAILABLE",
+    require_approval: false,
+    visibility: "private",
+    availability_zone: "eu-de-1a",
+    proxy_protocol: false,
+    connection_mirroring: false,
+    protocol: "HTTP",
+    provider: "tenant",
+    tags: ["devops", "ci"],
+    health_status: "ONLINE",
+    host: "jenkins.devops.example.com",
+    project_id: DEVOPS_PROJECT,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-06-01T00:00:00Z",
+  },
+  {
+    id: SVC_REGISTRY,
+    name: "Container Registry",
+    description: "Docker container registry",
+    enabled: true,
+    ports: [443, 5000],
+    network_id: NET_DEVELOPMENT,
+    ip_addresses: ["10.200.3.20"],
+    status: "AVAILABLE",
+    require_approval: false,
+    visibility: "public",
+    availability_zone: "eu-de-1b",
+    proxy_protocol: false,
+    connection_mirroring: false,
+    protocol: "HTTP",
+    provider: "tenant",
+    tags: ["devops", "registry"],
+    health_status: "ONLINE",
+    host: "registry.devops.example.com",
+    project_id: DEVOPS_PROJECT,
+    created_at: "2024-01-15T00:00:00Z",
+    updated_at: "2024-06-01T00:00:00Z",
+  },
+  {
+    id: SVC_VAULT,
+    name: "Vault Secrets",
+    description: "HashiCorp Vault for secrets management",
+    enabled: true,
+    ports: [8200],
+    network_id: NET_SHARED,
+    ip_addresses: ["10.200.3.30"],
+    status: "AVAILABLE",
+    require_approval: true,
+    visibility: "private",
+    availability_zone: "eu-de-1a",
+    proxy_protocol: false,
+    connection_mirroring: false,
+    protocol: "HTTP",
+    provider: "tenant",
+    tags: ["devops", "secrets"],
+    health_status: "ONLINE",
+    host: "vault.devops.example.com",
+    project_id: DEVOPS_PROJECT,
+    created_at: "2024-02-01T00:00:00Z",
+    updated_at: "2024-06-01T00:00:00Z",
+  },
+
+  // === EDGE CASE SERVICE (keep for testing) ===
+  {
+    id: SVC_EDGE,
+    name: "🚀 Über-Spëcial «Sèrvice» with <HTML> & \"quotes\" + 'apostrophes' — ™®© ½⅓ μs → ∞",
+    description: `A very long description that tests edge cases: <script>alert("xss")</script> & special chars like äöüß 中文 日本語 한국어 العربية עברית emoji: 🎉🔥💯🤖
+
+Line breaks and\ttabs and "nested 'quotes'" plus $variables \${interpolation} and \`backticks\`.
+
+Mathematical symbols: ∑∏∫∂∇ ≤≥≠≈ ±×÷ √∛∜ ∈∉⊂⊃ ∩∪ ∀∃
+
+Currency & units: €£¥₹₽ 100°C 45° 1024KB/s
+
+Regex-like patterns: /^[a-z]+$/gi .*? (foo|bar) [^abc]
+
+Path-like strings: /usr/local/bin/../lib C:\\Windows\\System32 file://localhost
+
+URL fragments: https://example.com/path?query=value&foo=bar#anchor
+
+Shell injection attempts: ; rm -rf / && echo "pwned" | sudo dd if=/dev/zero`,
+    enabled: true,
+    ports: [
+      1, 22, 80, 443, 1024, 1433, 1521, 3306, 3389, 5432, 5900, 6379, 8080, 8443, 9000, 9090, 9200, 9300, 11211, 27017,
+      50000, 65535,
+    ],
+    network_id: "99999999-9999-4999-8999-999999999999",
+    ip_addresses: ["10.255.255.1", "10.255.255.2", "10.255.255.3", "192.168.100.100", "172.16.0.1"],
+    status: "UNAVAILABLE",
+    require_approval: true,
+    visibility: "private",
+    availability_zone: "eu-de-1c",
+    proxy_protocol: true,
+    connection_mirroring: true,
+    protocol: "TCP",
+    provider: "tenant",
+    tags: ["edge-case", "test<tag>", "über", "🏷️emoji", "tag with spaces", "a".repeat(50)],
+    health_status: "OFFLINE",
+    host: "host-003.example.com",
+    project_id: OWN_PROJECT,
+    created_at: "2020-01-01T00:00:00Z",
+    updated_at: "2026-12-31T23:59:59Z",
+  },
+];
+
+const endpoints: Endpoint[] = [
+  // === OWN PROJECT ENDPOINTS ===
+  // Endpoint to own PostgreSQL
+  {
+    id: EP_OWN_POSTGRES_1,
+    service_id: SVC_POSTGRES,
+    name: "App DB Connection",
+    description: "Main application database connection",
+    target: { network: NET_PRODUCTION },
+    ip_address: "192.168.1.100",
+    status: "AVAILABLE",
+    tags: ["prod", "database"],
+    project_id: OWN_PROJECT,
+    created_at: "2024-01-16T11:00:00Z",
+    updated_at: "2024-01-16T11:00:00Z",
+  },
+  // Second endpoint to own PostgreSQL
+  {
+    id: EP_OWN_POSTGRES_2,
+    service_id: SVC_POSTGRES,
+    name: "Backup DB Connection",
+    description: "Backup service database connection",
+    target: { network: NET_PRODUCTION },
+    ip_address: "192.168.1.105",
+    status: "AVAILABLE",
+    tags: ["prod", "backup"],
+    project_id: OWN_PROJECT,
+    created_at: "2024-01-20T11:00:00Z",
+    updated_at: "2024-01-20T11:00:00Z",
+  },
+  // Third endpoint to own PostgreSQL
+  {
+    id: EP_OWN_POSTGRES_3,
+    service_id: SVC_POSTGRES,
+    name: "Analytics DB Reader",
+    description: "Read-only connection for analytics",
+    target: { network: NET_ANALYTICS },
+    ip_address: "192.168.1.106",
+    status: "AVAILABLE",
+    tags: ["analytics", "readonly"],
+    project_id: OWN_PROJECT,
+    created_at: "2024-06-01T11:00:00Z",
+    updated_at: "2024-06-01T11:00:00Z",
+  },
+  // Endpoint to own Redis
+  {
+    id: EP_OWN_REDIS_1,
+    service_id: SVC_REDIS,
+    name: "Cache Connection",
+    description: "Application cache connection",
+    target: { network: NET_PRODUCTION },
+    ip_address: "192.168.1.101",
+    status: "AVAILABLE",
+    tags: ["prod", "cache"],
+    project_id: OWN_PROJECT,
+    created_at: "2024-02-02T09:00:00Z",
+    updated_at: "2024-02-02T09:00:00Z",
+  },
+  // Second endpoint to own Redis
+  {
+    id: EP_OWN_REDIS_2,
+    service_id: SVC_REDIS,
+    name: "Session Cache",
+    description: "Session storage cache connection",
+    target: { network: NET_PRODUCTION },
+    ip_address: "192.168.1.107",
+    status: "AVAILABLE",
+    tags: ["prod", "sessions"],
+    project_id: OWN_PROJECT,
+    created_at: "2024-02-05T09:00:00Z",
+    updated_at: "2024-02-05T09:00:00Z",
+  },
+  // Endpoint to own Kafka
+  {
+    id: EP_OWN_KAFKA_1,
+    service_id: SVC_KAFKA,
+    name: "Event Stream",
+    description: "Kafka event streaming endpoint",
+    target: { network: NET_PRODUCTION },
+    ip_address: "192.168.1.102",
+    status: "AVAILABLE",
+    tags: ["prod", "events"],
+    project_id: OWN_PROJECT,
+    created_at: "2024-03-05T10:00:00Z",
+    updated_at: "2024-03-05T10:00:00Z",
+  },
+  // Endpoint to managed API Gateway
+  {
+    id: EP_OWN_APIGW_1,
+    service_id: SVC_CP_APIGW,
+    name: "API Gateway",
+    description: "Connection to managed API gateway",
+    target: { network: NET_SHARED },
+    ip_address: "192.168.1.200",
+    status: "AVAILABLE",
+    tags: ["api", "managed"],
+    project_id: OWN_PROJECT,
+    created_at: "2024-01-20T08:00:00Z",
+    updated_at: "2024-01-20T08:00:00Z",
+  },
+  // Endpoint to managed Identity
+  {
+    id: EP_OWN_IDENTITY_1,
+    service_id: SVC_CP_IDENTITY,
+    name: "Identity Access",
+    description: "Authentication service connection",
+    target: { network: NET_SHARED },
+    ip_address: "192.168.1.201",
+    status: "AVAILABLE",
+    tags: ["auth", "managed"],
+    project_id: OWN_PROJECT,
+    created_at: "2024-06-01T08:00:00Z",
+    updated_at: "2024-06-01T08:00:00Z",
+  },
+  // Endpoint to managed Logging
+  {
+    id: EP_OWN_LOGGING_1,
+    service_id: SVC_CP_LOGGING,
+    name: "Log Shipping",
+    description: "Centralized logging connection",
+    target: { network: NET_SHARED },
+    ip_address: "192.168.1.202",
+    status: "AVAILABLE",
+    tags: ["logging", "managed"],
+    project_id: OWN_PROJECT,
+    created_at: "2024-02-01T08:00:00Z",
+    updated_at: "2024-02-01T08:00:00Z",
+  },
+  // Endpoint to Finance DB (cross-project)
+  {
+    id: EP_OWN_FINANCE_1,
+    service_id: SVC_FINANCE_DB,
+    name: "Finance Data",
+    description: "Read access to financial data warehouse",
+    target: { network: NET_ANALYTICS },
+    ip_address: "192.168.1.150",
+    status: "AVAILABLE",
+    tags: ["finance", "reporting"],
+    project_id: OWN_PROJECT,
+    created_at: "2024-03-01T08:00:00Z",
+    updated_at: "2024-03-01T08:00:00Z",
+  },
+  // Endpoint to Analytics Spark
+  {
+    id: EP_OWN_SPARK_1,
+    service_id: SVC_SPARK,
+    name: "Spark Jobs",
+    description: "Analytics processing cluster access",
+    target: { network: NET_ANALYTICS },
+    ip_address: "192.168.1.151",
+    status: "AVAILABLE",
+    tags: ["analytics", "spark"],
+    project_id: OWN_PROJECT,
+    created_at: "2024-05-01T08:00:00Z",
+    updated_at: "2024-05-01T08:00:00Z",
+  },
+  // Endpoint to DevOps Vault
+  {
+    id: EP_OWN_VAULT_1,
+    service_id: SVC_VAULT,
+    name: "Secrets Access",
+    description: "Vault secrets management",
+    target: { network: NET_SHARED },
+    ip_address: "192.168.1.160",
+    status: "AVAILABLE",
+    tags: ["secrets", "devops"],
+    project_id: OWN_PROJECT,
+    created_at: "2024-02-15T08:00:00Z",
+    updated_at: "2024-02-15T08:00:00Z",
+  },
+  // Endpoint to DevOps Registry
+  {
+    id: EP_OWN_REGISTRY_1,
+    service_id: SVC_REGISTRY,
+    name: "Container Pull",
+    description: "Docker image pull access",
+    target: { network: NET_DEVELOPMENT },
+    ip_address: "192.168.1.161",
+    status: "AVAILABLE",
+    tags: ["docker", "devops"],
+    project_id: OWN_PROJECT,
+    created_at: "2024-01-20T08:00:00Z",
+    updated_at: "2024-01-20T08:00:00Z",
+  },
+
+  // === EXTERNAL PROJECT ENDPOINTS (other projects connecting to our services) ===
+  // Finance project endpoint to our PostgreSQL
+  {
+    id: EP_FINANCE_POSTGRES_1,
+    service_id: SVC_POSTGRES,
+    name: "Reporting DB",
+    description: "Finance reporting database access",
+    target: { subnet: SUBNET_ANALYTICS },
+    ip_address: "192.168.2.100",
+    status: "AVAILABLE",
+    tags: ["reporting"],
+    project_id: FINANCE_PROJECT,
+    created_at: "2024-02-01T10:00:00Z",
+    updated_at: "2024-02-01T10:00:00Z",
+  },
+  // Analytics project endpoint to our Kafka
+  {
+    id: EP_ANALYTICS_KAFKA_1,
+    service_id: SVC_KAFKA,
+    name: "Event Consumer",
+    description: "Analytics event stream consumer",
+    target: { network: NET_ANALYTICS },
+    ip_address: "192.168.3.100",
+    status: "PENDING_APPROVAL",
+    tags: ["events", "analytics"],
+    project_id: ANALYTICS_PROJECT,
+    created_at: "2024-04-01T10:00:00Z",
+    updated_at: "2024-04-01T10:00:00Z",
+  },
+  // DevOps project endpoint to our Elasticsearch
+  {
+    id: EP_DEVOPS_ES_1,
+    service_id: SVC_ELASTICSEARCH,
+    name: "Log Search",
+    description: "Centralized log search access",
+    target: { network: NET_STAGING },
+    ip_address: "192.168.4.100",
+    status: "AVAILABLE",
+    tags: ["logging", "search"],
+    project_id: DEVOPS_PROJECT,
+    created_at: "2024-04-15T10:00:00Z",
+    updated_at: "2024-04-15T10:00:00Z",
+  },
+  // DevOps project endpoint to our Grafana
+  {
+    id: EP_DEVOPS_GRAFANA_1,
+    service_id: SVC_GRAFANA,
+    name: "Monitoring View",
+    description: "Observability dashboard access",
+    target: { network: NET_SHARED },
+    ip_address: "192.168.4.101",
+    status: "REJECTED",
+    tags: ["monitoring"],
+    project_id: DEVOPS_PROJECT,
+    created_at: "2024-05-20T10:00:00Z",
+    updated_at: "2024-05-25T10:00:00Z",
+  },
+];
+
+const consumers: EndpointConsumer[] = [
+  // Own project endpoints
+  { id: EP_OWN_POSTGRES_1, status: "AVAILABLE", project_id: OWN_PROJECT },
+  { id: EP_OWN_POSTGRES_2, status: "AVAILABLE", project_id: OWN_PROJECT },
+  { id: EP_OWN_POSTGRES_3, status: "AVAILABLE", project_id: OWN_PROJECT },
+  { id: EP_OWN_REDIS_1, status: "AVAILABLE", project_id: OWN_PROJECT },
+  { id: EP_OWN_REDIS_2, status: "AVAILABLE", project_id: OWN_PROJECT },
+  { id: EP_OWN_KAFKA_1, status: "AVAILABLE", project_id: OWN_PROJECT },
+  { id: EP_OWN_APIGW_1, status: "AVAILABLE", project_id: OWN_PROJECT },
+  { id: EP_OWN_IDENTITY_1, status: "AVAILABLE", project_id: OWN_PROJECT },
+  { id: EP_OWN_LOGGING_1, status: "AVAILABLE", project_id: OWN_PROJECT },
+  { id: EP_OWN_FINANCE_1, status: "AVAILABLE", project_id: OWN_PROJECT },
+  { id: EP_OWN_SPARK_1, status: "AVAILABLE", project_id: OWN_PROJECT },
+  { id: EP_OWN_VAULT_1, status: "AVAILABLE", project_id: OWN_PROJECT },
+  { id: EP_OWN_REGISTRY_1, status: "AVAILABLE", project_id: OWN_PROJECT },
+  // External project endpoints requesting access to our services
+  { id: EP_FINANCE_POSTGRES_1, status: "AVAILABLE", project_id: FINANCE_PROJECT },
+  { id: EP_ANALYTICS_KAFKA_1, status: "PENDING_APPROVAL", project_id: ANALYTICS_PROJECT },
+  { id: EP_DEVOPS_ES_1, status: "AVAILABLE", project_id: DEVOPS_PROJECT },
+  { id: EP_DEVOPS_GRAFANA_1, status: "REJECTED", project_id: DEVOPS_PROJECT },
+];
+
+// Mock agents
+const agents: Agent[] = [
+  {
+    host: "archer-agent-eu-de-1a-001.cloud.sap",
+    availability_zone: "eu-de-1a",
+    provider: "tenant",
+    enabled: true,
+    physnet: "physnet1",
+    created_at: "2025-01-15T10:00:00Z",
+    updated_at: "2026-04-21T08:30:00Z",
+    heartbeat_at: new Date(Date.now() - 10 * 1000).toISOString(), // 10 seconds ago
+    services: 12,
+  },
+  {
+    host: "archer-agent-eu-de-1a-002.cloud.sap",
+    availability_zone: "eu-de-1a",
+    provider: "tenant",
+    enabled: true,
+    physnet: "physnet1",
+    created_at: "2025-01-15T10:05:00Z",
+    updated_at: "2026-04-21T08:30:00Z",
+    heartbeat_at: new Date(Date.now() - 5 * 1000).toISOString(), // 5 seconds ago
+    services: 8,
+  },
+  {
+    host: "archer-agent-eu-de-1b-001.cloud.sap",
+    availability_zone: "eu-de-1b",
+    provider: "tenant",
+    enabled: true,
+    physnet: "physnet2",
+    created_at: "2025-02-01T14:00:00Z",
+    updated_at: "2026-04-21T08:25:00Z",
+    heartbeat_at: new Date(Date.now() - 45 * 1000).toISOString(), // 45 seconds ago (yellow)
+    services: 15,
+  },
+  {
+    host: "archer-agent-eu-de-1b-002.cloud.sap",
+    availability_zone: "eu-de-1b",
+    provider: "tenant",
+    enabled: false,
+    physnet: "physnet2",
+    created_at: "2025-02-01T14:05:00Z",
+    updated_at: "2026-04-20T16:00:00Z",
+    heartbeat_at: new Date(Date.now() - 10 * 60 * 1000).toISOString(), // 10 minutes ago (red)
+    services: 0,
+  },
+  {
+    host: "archer-cp-agent-eu-de-1a-001.cloud.sap",
+    availability_zone: "eu-de-1a",
+    provider: "cp",
+    enabled: true,
+    physnet: "cp-physnet",
+    created_at: "2025-03-01T09:00:00Z",
+    updated_at: "2026-04-21T08:30:00Z",
+    heartbeat_at: new Date(Date.now() - 3 * 1000).toISOString(), // 3 seconds ago
+    services: 5,
+  },
+  {
+    host: "archer-cp-agent-eu-de-1b-001.cloud.sap",
+    availability_zone: "eu-de-1b",
+    provider: "cp",
+    enabled: true,
+    physnet: "cp-physnet",
+    created_at: "2025-03-01T09:05:00Z",
+    updated_at: "2026-04-21T08:28:00Z",
+    heartbeat_at: new Date(Date.now() - 20 * 1000).toISOString(), // 20 seconds ago
+    services: 3,
+  },
+];
+
+// Mock Neutron networks
+const networks: Network[] = [
+  {
+    id: NET_PRODUCTION,
+    name: "Production Network",
+    status: "ACTIVE",
+    subnets: [SUBNET_PRODUCTION],
+    project_id: OWN_PROJECT,
+  },
+  {
+    id: NET_STAGING,
+    name: "Staging Network",
+    status: "ACTIVE",
+    subnets: [SUBNET_STAGING],
+    project_id: OWN_PROJECT,
+  },
+  {
+    id: NET_DEVELOPMENT,
+    name: "Development Network",
+    status: "ACTIVE",
+    subnets: [SUBNET_DEVELOPMENT],
+    project_id: OWN_PROJECT,
+  },
+  {
+    id: NET_SHARED,
+    name: "Shared Services",
+    status: "ACTIVE",
+    subnets: [SUBNET_SHARED],
+    project_id: OWN_PROJECT,
+  },
+  {
+    id: NET_ANALYTICS,
+    name: "Analytics Network",
+    status: "ACTIVE",
+    subnets: [SUBNET_ANALYTICS],
+    project_id: OWN_PROJECT,
+  },
+  {
+    id: NET_BACKUP,
+    name: "Backup Network",
+    status: "ACTIVE",
+    subnets: [SUBNET_BACKUP],
+    project_id: OWN_PROJECT,
+  },
+  {
+    id: NET_DMZ,
+    name: "DMZ Network",
+    status: "ACTIVE",
+    subnets: [],
+    project_id: OWN_PROJECT,
+  },
+  {
+    id: NET_INTERNAL,
+    name: "Internal Services",
+    status: "ACTIVE",
+    subnets: [],
+    project_id: OWN_PROJECT,
+  },
+];
+
+// Mock Neutron subnets
+const subnets: Subnet[] = [
+  {
+    id: SUBNET_PRODUCTION,
+    name: "Production Subnet",
+    network_id: NET_PRODUCTION,
+    cidr: "10.0.1.0/24",
+    ip_version: 4,
+    project_id: OWN_PROJECT,
+  },
+  {
+    id: SUBNET_STAGING,
+    name: "Staging Subnet",
+    network_id: NET_STAGING,
+    cidr: "10.0.2.0/24",
+    ip_version: 4,
+    project_id: OWN_PROJECT,
+  },
+  {
+    id: SUBNET_DEVELOPMENT,
+    name: "Development Subnet",
+    network_id: NET_DEVELOPMENT,
+    cidr: "10.0.3.0/24",
+    ip_version: 4,
+    project_id: OWN_PROJECT,
+  },
+  {
+    id: SUBNET_SHARED,
+    name: "Shared Subnet",
+    network_id: NET_SHARED,
+    cidr: "10.0.4.0/24",
+    ip_version: 4,
+    project_id: OWN_PROJECT,
+  },
+  {
+    id: SUBNET_ANALYTICS,
+    name: "Analytics Subnet",
+    network_id: NET_ANALYTICS,
+    cidr: "10.200.0.0/24",
+    ip_version: 4,
+    project_id: OWN_PROJECT,
+  },
+  {
+    id: SUBNET_BACKUP,
+    name: "Backup Subnet",
+    network_id: NET_BACKUP,
+    cidr: "10.100.0.0/24",
+    ip_version: 4,
+    project_id: OWN_PROJECT,
+  },
+];
+
+// Mock Neutron ports (mix of bound and unbound)
+const ports: Port[] = [
+  // Bound ports (attached to instances)
+  {
+    id: PORT_PROD_WEB,
+    name: "Web Server Port",
+    network_id: NET_PRODUCTION,
+    status: "ACTIVE",
+    device_owner: "compute:nova",
+    device_id: "ccc00001-0001-4001-8001-000000000001",
+    fixed_ips: [{ subnet_id: SUBNET_PRODUCTION, ip_address: "10.0.1.10" }],
+    project_id: OWN_PROJECT,
+  },
+  {
+    id: PORT_PROD_DB,
+    name: "Database Port",
+    network_id: NET_PRODUCTION,
+    status: "ACTIVE",
+    device_owner: "compute:nova",
+    device_id: "ccc00002-0002-4002-8002-000000000002",
+    fixed_ips: [{ subnet_id: SUBNET_PRODUCTION, ip_address: "10.0.1.20" }],
+    project_id: OWN_PROJECT,
+  },
+  // Unbound ports (available for selection)
+  {
+    id: PORT_STAGING_APP,
+    name: "App Server Port",
+    network_id: NET_STAGING,
+    status: "DOWN",
+    device_owner: "",
+    device_id: "",
+    fixed_ips: [{ subnet_id: SUBNET_STAGING, ip_address: "10.0.2.10" }],
+    project_id: OWN_PROJECT,
+  },
+  {
+    id: PORT_DEV_TEST,
+    name: "Test Instance",
+    network_id: NET_DEVELOPMENT,
+    status: "DOWN",
+    device_owner: "",
+    device_id: "",
+    fixed_ips: [{ subnet_id: SUBNET_DEVELOPMENT, ip_address: "10.0.3.50" }],
+    project_id: OWN_PROJECT,
+  },
+  {
+    id: PORT_SHARED_LB,
+    name: "Load Balancer VIP",
+    network_id: NET_SHARED,
+    status: "DOWN",
+    device_owner: "",
+    device_id: "",
+    fixed_ips: [{ subnet_id: SUBNET_SHARED, ip_address: "10.0.4.100" }],
+    project_id: OWN_PROJECT,
+  },
+  {
+    id: PORT_RESERVED,
+    name: "Reserved Port",
+    network_id: NET_PRODUCTION,
+    status: "DOWN",
+    device_owner: "",
+    device_id: "",
+    fixed_ips: [{ subnet_id: SUBNET_PRODUCTION, ip_address: "10.0.1.50" }],
+    project_id: OWN_PROJECT,
+  },
+];
+
+const rbacPolicies: RBACPolicy[] = [
+  // Allow Finance project to access our PostgreSQL
+  {
+    id: "01234567-0001-4001-8001-000000000001",
+    service_id: SVC_POSTGRES,
+    target_type: "project",
+    target: FINANCE_PROJECT,
+    project_id: OWN_PROJECT,
+    created_at: "2024-01-17T10:00:00Z",
+    updated_at: "2024-01-17T10:00:00Z",
+  },
+  // Allow Analytics project to access our Kafka
+  {
+    id: "01234567-0002-4002-8002-000000000002",
+    service_id: SVC_KAFKA,
+    target_type: "project",
+    target: ANALYTICS_PROJECT,
+    project_id: OWN_PROJECT,
+    created_at: "2024-03-01T10:00:00Z",
+    updated_at: "2024-03-01T10:00:00Z",
+  },
+  // Allow DevOps project to access our Elasticsearch
+  {
+    id: "01234567-0003-4003-8003-000000000003",
+    service_id: SVC_ELASTICSEARCH,
+    target_type: "project",
+    target: DEVOPS_PROJECT,
+    project_id: OWN_PROJECT,
+    created_at: "2024-04-10T10:00:00Z",
+    updated_at: "2024-04-10T10:00:00Z",
+  },
+  // Allow DevOps project to access our Grafana
+  {
+    id: "01234567-0004-4004-8004-000000000004",
+    service_id: SVC_GRAFANA,
+    target_type: "project",
+    target: DEVOPS_PROJECT,
+    project_id: OWN_PROJECT,
+    created_at: "2024-05-01T10:00:00Z",
+    updated_at: "2024-05-01T10:00:00Z",
+  },
+  // Wildcard RBAC for Redis (anyone can access)
+  {
+    id: "01234567-0005-4005-8005-000000000005",
+    service_id: SVC_REDIS,
+    target_type: "project",
+    target: "*",
+    project_id: OWN_PROJECT,
+    created_at: "2024-02-01T10:00:00Z",
+    updated_at: "2024-02-01T10:00:00Z",
+  },
+];
+
+export const createHandlers = (baseUrl: string) => [
+  // Version
+  http.get(`${baseUrl}/`, () =>
+    HttpResponse.json({
+      version: "v2.0.0",
+      updated: "2026-04-01T00:00:00Z",
+    })
+  ),
+
+  // Services
+  http.get(`${baseUrl}/service`, () => HttpResponse.json({ items: services })),
+  http.get(`${baseUrl}/service/:id`, ({ params }) => {
+    const s = services.find((x) => x.id === params.id);
+    return s ? HttpResponse.json(s) : HttpResponse.json({ message: "Not found" }, { status: 404 });
+  }),
+  http.post(`${baseUrl}/service`, async ({ request }) => {
+    const body = (await request.json()) as Partial<Service>;
+    const newService: Service = {
+      ...body,
+      id: crypto.randomUUID(),
+      status: "PENDING_CREATE",
+      health_status: "UNCHECKED",
+      project_id: OWN_PROJECT,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    } as Service;
+    return HttpResponse.json(newService, { status: 201 });
+  }),
+  http.put(`${baseUrl}/service/:id`, async ({ params, request }) => {
+    const s = services.find((x) => x.id === params.id);
+    if (!s) return HttpResponse.json({ message: "Not found" }, { status: 404 });
+    const body = (await request.json()) as Partial<Service>;
+    return HttpResponse.json({ ...s, ...body, updated_at: new Date().toISOString() });
+  }),
+  http.delete(`${baseUrl}/service/:id`, ({ params }) => {
+    const s = services.find((x) => x.id === params.id);
+    return s ? new HttpResponse(null, { status: 202 }) : HttpResponse.json({ message: "Not found" }, { status: 404 });
+  }),
+  http.get(`${baseUrl}/service/:id/endpoints`, ({ params }) => {
+    // Get endpoint IDs that belong to this service
+    const serviceEndpointIds = new Set(endpoints.filter((e) => e.service_id === params.id).map((e) => e.id));
+    // Return only consumers for those endpoints
+    const serviceConsumers = consumers.filter((c) => serviceEndpointIds.has(c.id));
+    return HttpResponse.json({ items: serviceConsumers });
+  }),
+  http.put(`${baseUrl}/service/:id/accept_endpoints`, async ({ request }) => {
+    const { endpoint_ids } = (await request.json()) as { endpoint_ids: string[] };
+    return HttpResponse.json(
+      consumers.filter((c) => endpoint_ids.includes(c.id)).map((c) => ({ ...c, status: "AVAILABLE" }))
+    );
+  }),
+  http.put(`${baseUrl}/service/:id/reject_endpoints`, async ({ request }) => {
+    const { endpoint_ids } = (await request.json()) as { endpoint_ids: string[] };
+    return HttpResponse.json(
+      consumers.filter((c) => endpoint_ids.includes(c.id)).map((c) => ({ ...c, status: "REJECTED" }))
+    );
+  }),
+
+  // Endpoints
+  http.get(`${baseUrl}/endpoint`, () => HttpResponse.json({ items: endpoints })),
+  http.get(`${baseUrl}/endpoint/:id`, ({ params }) => {
+    const e = endpoints.find((x) => x.id === params.id);
+    return e ? HttpResponse.json(e) : HttpResponse.json({ message: "Not found" }, { status: 404 });
+  }),
+  http.post(`${baseUrl}/endpoint`, async ({ request }) => {
+    const body = (await request.json()) as Partial<Endpoint>;
+    const newEndpoint: Endpoint = {
+      ...body,
+      id: crypto.randomUUID(),
+      status: "PENDING_CREATE",
+      ip_address: `192.168.${Math.floor(Math.random() * 255)}.${Math.floor(Math.random() * 255)}`,
+      project_id: OWN_PROJECT,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    } as Endpoint;
+    return HttpResponse.json(newEndpoint, { status: 201 });
+  }),
+  http.put(`${baseUrl}/endpoint/:id`, async ({ params, request }) => {
+    const e = endpoints.find((x) => x.id === params.id);
+    if (!e) return HttpResponse.json({ message: "Not found" }, { status: 404 });
+    const body = (await request.json()) as Partial<Endpoint>;
+    return HttpResponse.json({ ...e, ...body, updated_at: new Date().toISOString() });
+  }),
+  http.delete(`${baseUrl}/endpoint/:id`, ({ params }) => {
+    const e = endpoints.find((x) => x.id === params.id);
+    return e ? new HttpResponse(null, { status: 202 }) : HttpResponse.json({ message: "Not found" }, { status: 404 });
+  }),
+
+  // RBAC
+  http.get(`${baseUrl}/rbac-policies`, () => HttpResponse.json({ items: rbacPolicies })),
+  http.post(`${baseUrl}/rbac-policies`, async ({ request }) => {
+    const body = (await request.json()) as Partial<RBACPolicy>;
+    const newPolicy: RBACPolicy = {
+      ...body,
+      id: `rbac-${crypto.randomUUID()}`,
+      target_type: "project",
+      project_id: OWN_PROJECT,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    } as RBACPolicy;
+    return HttpResponse.json(newPolicy, { status: 201 });
+  }),
+  http.put(`${baseUrl}/rbac-policies/:id`, async ({ params, request }) => {
+    const p = rbacPolicies.find((x) => x.id === params.id);
+    if (!p) return HttpResponse.json({ message: "Not found" }, { status: 404 });
+    const body = (await request.json()) as Partial<RBACPolicy>;
+    return HttpResponse.json({ ...p, ...body, updated_at: new Date().toISOString() });
+  }),
+  http.delete(`${baseUrl}/rbac-policies/:id`, ({ params }) => {
+    const p = rbacPolicies.find((x) => x.id === params.id);
+    return p ? new HttpResponse(null, { status: 204 }) : HttpResponse.json({ message: "Not found" }, { status: 404 });
+  }),
+
+  // Agents
+  http.get(`${baseUrl}/agents`, () => HttpResponse.json({ items: agents })),
+
+  // Neutron Networks (mock - matches any neutron endpoint)
+  http.get(/.*\/v2\.0\/networks.*/, () => HttpResponse.json({ networks })),
+  http.get(/.*\/v2\.0\/subnets.*/, () => HttpResponse.json({ subnets })),
+  http.get(/.*\/v2\.0\/ports.*/, () => HttpResponse.json({ ports })),
+];

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import type { Service, Endpoint, RBACPolicy, Provider } from "./types";
+
+interface GlobalAPI {
+  apiReady: boolean;
+  endpoint: string;
+  token: string;
+  projectID: string;
+  archerctlUrl: string;
+  docsUrl: string;
+  theme: "theme-dark" | "theme-light";
+  neutronEndpoint: string;
+  cloudAdmin: boolean;
+}
+
+interface DeleteTarget {
+  type: "service" | "endpoint" | "rbac";
+  item: Service | Endpoint | RBACPolicy;
+}
+
+export interface ToastMessage {
+  id: string;
+  variant: "success" | "warning" | "danger";
+  message: string;
+  timestamp: number;
+}
+
+interface AppState {
+  // API state
+  globalAPI: GlobalAPI;
+  setGlobalAPI: (api: Partial<GlobalAPI>) => void;
+  setToken: (token: string) => void;
+  setApiReady: (ready: boolean) => void;
+
+  // Toast state
+  toasts: ToastMessage[];
+  addToast: (toast: Omit<ToastMessage, "id" | "timestamp">) => void;
+  dismissToast: (id: string) => void;
+  clearToasts: () => void;
+
+  // UI state
+  showServiceModal: boolean;
+  showEndpointModal: boolean;
+  showRBACModal: boolean;
+  showDeleteModal: boolean;
+  showMigrateModal: boolean;
+  editService: Service | null;
+  editEndpoint: Endpoint | null;
+  editRBAC: RBACPolicy | null;
+  deleteTarget: DeleteTarget | null;
+  preselectedServiceId: string | null;
+  createServiceProvider: Provider | null;
+  migrateService: Service | null;
+
+  // UI actions
+  openServiceModal: (service?: Service | null, provider?: Provider | null) => void;
+  openEndpointModal: (endpoint?: Endpoint | null, preselectedServiceId?: string | null) => void;
+  openRBACModal: (policy?: RBACPolicy | null) => void;
+  openDeleteModal: (target: DeleteTarget) => void;
+  openMigrateModal: (service: Service) => void;
+  closeModals: () => void;
+}
+
+export const useStore = create<AppState>()(
+  devtools((set) => ({
+    // API state
+    globalAPI: {
+      apiReady: false,
+      endpoint: "",
+      token: "",
+      projectID: "",
+      archerctlUrl: "",
+      docsUrl: "",
+      theme: "theme-dark",
+      neutronEndpoint: "",
+      cloudAdmin: false,
+    },
+    setGlobalAPI: (api) => set((state) => ({ globalAPI: { ...state.globalAPI, ...api } })),
+    setToken: (token) => set((state) => ({ globalAPI: { ...state.globalAPI, token } })),
+    setApiReady: (apiReady) => set((state) => ({ globalAPI: { ...state.globalAPI, apiReady } })),
+
+    // Toast state
+    toasts: [],
+    addToast: (toast) =>
+      set((state) => ({
+        toasts: [{ ...toast, id: `${Date.now()}-${Math.random()}`, timestamp: Date.now() }, ...state.toasts],
+      })),
+    dismissToast: (id) => set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) })),
+    clearToasts: () => set({ toasts: [] }),
+
+    // UI state
+    showServiceModal: false,
+    showEndpointModal: false,
+    showRBACModal: false,
+    showDeleteModal: false,
+    showMigrateModal: false,
+    editService: null,
+    editEndpoint: null,
+    editRBAC: null,
+    deleteTarget: null,
+    preselectedServiceId: null,
+    createServiceProvider: null,
+    migrateService: null,
+
+    // UI actions
+    openServiceModal: (service = null, provider = null) =>
+      set({ showServiceModal: true, editService: service, createServiceProvider: provider }),
+    openEndpointModal: (endpoint = null, preselectedServiceId = null) =>
+      set({ showEndpointModal: true, editEndpoint: endpoint, preselectedServiceId }),
+    openRBACModal: (policy = null) => set({ showRBACModal: true, editRBAC: policy }),
+    openDeleteModal: (target) => set({ showDeleteModal: true, deleteTarget: target }),
+    openMigrateModal: (service) => set({ showMigrateModal: true, migrateService: service }),
+    closeModals: () =>
+      set({
+        showServiceModal: false,
+        showEndpointModal: false,
+        showRBACModal: false,
+        showDeleteModal: false,
+        showMigrateModal: false,
+        editService: null,
+        editEndpoint: null,
+        editRBAC: null,
+        deleteTarget: null,
+        preselectedServiceId: null,
+        createServiceProvider: null,
+        migrateService: null,
+      }),
+  }))
+);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,0 +1,58 @@
+/* SPDX-FileCopyrightText: 2024 SAP SE */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+@import "tailwindcss";
+@import "@xyflow/react/dist/style.css";
+
+/* Override ReactFlow background in dark mode */
+.react-flow {
+  background: transparent !important;
+}
+
+.react-flow__background {
+  background: transparent !important;
+}
+
+/* Pulsating effect for pending status badges */
+@keyframes pulse-pending {
+  0% {
+    box-shadow: 0 0 4px 1px color-mix(in srgb, var(--color-warning) 40%, transparent);
+  }
+  50% {
+    box-shadow: 0 0 10px 3px color-mix(in srgb, var(--color-warning) 60%, transparent);
+  }
+  100% {
+    box-shadow: 0 0 4px 1px color-mix(in srgb, var(--color-warning) 40%, transparent);
+  }
+}
+
+@keyframes pulse-pending-info {
+  0% {
+    box-shadow: 0 0 4px 1px color-mix(in srgb, var(--color-info) 40%, transparent);
+  }
+  50% {
+    box-shadow: 0 0 10px 3px color-mix(in srgb, var(--color-info) 60%, transparent);
+  }
+  100% {
+    box-shadow: 0 0 4px 1px color-mix(in srgb, var(--color-info) 40%, transparent);
+  }
+}
+
+@layer utilities {
+  .animate-pulse-pending {
+    animation: pulse-pending 2s ease-in-out infinite !important;
+  }
+}
+
+/* Pulsating glow used by NetworkGraph nodes for pending status */
+@keyframes pulse-glow {
+  0% {
+    box-shadow: 0 0 8px 2px rgba(234, 179, 8, 0.3);
+  }
+  50% {
+    box-shadow: 0 0 18px 6px rgba(234, 179, 8, 0.5);
+  }
+  100% {
+    box-shadow: 0 0 8px 2px rgba(234, 179, 8, 0.3);
+  }
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: 2026 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+// Archer API Types - derived from swagger.yaml
+
+export type ServiceStatus =
+  | "AVAILABLE"
+  | "PENDING_CREATE"
+  | "PENDING_UPDATE"
+  | "PENDING_DELETE"
+  | "UNAVAILABLE"
+  | "ERROR_QUOTA";
+
+export type EndpointStatus =
+  | "AVAILABLE"
+  | "PENDING_APPROVAL"
+  | "PENDING_CREATE"
+  | "PENDING_UPDATE"
+  | "PENDING_REJECTED"
+  | "PENDING_DELETE"
+  | "REJECTED"
+  | "FAILED";
+
+export type HealthStatus = "ONLINE" | "DEGRADED" | "OFFLINE" | "UNCHECKED";
+export type Visibility = "private" | "public";
+export type Protocol = "HTTP" | "TCP";
+export type Provider = "tenant" | "cp";
+
+export interface Service {
+  id: string;
+  name: string | null;
+  description: string | null;
+  enabled: boolean;
+  ports: number[];
+  network_id: string;
+  ip_addresses: string[];
+  status: ServiceStatus;
+  require_approval: boolean;
+  visibility: Visibility;
+  availability_zone: string | null;
+  proxy_protocol: boolean;
+  connection_mirroring: boolean;
+  protocol: Protocol;
+  provider: Provider | null;
+  tags: string[] | null;
+  health_status: HealthStatus | null;
+  host: string | null;
+  project_id: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ServiceCreate {
+  name?: string;
+  description?: string;
+  ports: number[];
+  network_id: string;
+  ip_addresses: string[];
+  enabled?: boolean;
+  require_approval?: boolean;
+  visibility?: Visibility;
+  proxy_protocol?: boolean;
+  connection_mirroring?: boolean;
+  protocol?: Protocol;
+  tags?: string[];
+  provider?: Provider;
+}
+
+export interface ServiceUpdate {
+  name?: string | null;
+  description?: string | null;
+  enabled?: boolean;
+  ip_addresses?: string[];
+  ports?: number[];
+  require_approval?: boolean;
+  visibility?: Visibility;
+  proxy_protocol?: boolean;
+  connection_mirroring?: boolean;
+  protocol?: Protocol;
+  tags?: string[];
+}
+
+export interface EndpointTarget {
+  network?: string | null;
+  subnet?: string | null;
+  port?: string | null;
+}
+
+export interface Endpoint {
+  id: string;
+  service_id: string;
+  name: string | null;
+  description: string | null;
+  target: EndpointTarget;
+  ip_address: string;
+  status: EndpointStatus;
+  tags: string[] | null;
+  project_id: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface EndpointCreate {
+  service_id: string;
+  name?: string;
+  description?: string;
+  target: EndpointTarget;
+  tags?: string[];
+}
+
+export interface EndpointUpdate {
+  name?: string | null;
+  description?: string | null;
+  tags?: string[] | null;
+}
+
+export interface EndpointConsumer {
+  id: string;
+  status: EndpointStatus;
+  project_id: string;
+}
+
+export interface RBACPolicy {
+  id: string;
+  service_id: string;
+  target_type: "project";
+  target: string;
+  project_id: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface RBACPolicyCreate {
+  service_id: string;
+  target_type?: "project";
+  target: string;
+}
+
+export interface RBACPolicyUpdate {
+  target: string;
+}
+
+export interface Agent {
+  host: string;
+  availability_zone: string;
+  provider: Provider;
+  enabled: boolean;
+  physnet: string;
+  created_at: string;
+  updated_at: string;
+  heartbeat_at: string;
+  services: number;
+}
+
+export interface ListResponse<T> {
+  items: T[];
+  links?: { href: string; rel: string }[];
+}
+
+export interface Version {
+  version: string;
+  updated: string;
+  links?: { href: string; rel: string }[];
+}
+
+// OpenStack Network (from Neutron API)
+export interface Network {
+  id: string;
+  name: string;
+  status: string;
+  subnets: string[];
+  project_id: string;
+}
+
+export interface NetworksResponse {
+  networks: Network[];
+}
+
+// OpenStack Subnet (from Neutron API)
+export interface Subnet {
+  id: string;
+  name: string;
+  network_id: string;
+  cidr: string;
+  ip_version: number;
+  project_id: string;
+}
+
+export interface SubnetsResponse {
+  subnets: Subnet[];
+}
+
+// OpenStack Port (from Neutron API)
+export interface Port {
+  id: string;
+  name: string;
+  network_id: string;
+  status: string;
+  device_owner: string;
+  device_id: string;
+  fixed_ips: { subnet_id: string; ip_address: string }[];
+  project_id: string;
+}
+
+export interface PortsResponse {
+  ports: Port[];
+}
+
+// App props passed from host
+export interface AppProps {
+  endpoint?: string;
+  projectID?: string;
+  token?: string;
+  canEdit?: boolean | string;
+  mockAPI?: boolean;
+  theme?: string;
+  embedded?: boolean | string;
+  getTokenFuncName?: string;
+  archerctlUrl?: string;
+  docsUrl?: string;
+  neutronEndpoint?: string;
+  cloudAdmin?: boolean | string;
+}

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+module.exports = {
+  presets: [require("@cloudoperators/juno-ui-components/build/lib/tailwind.config")],
+  content: ["./src/**/*.{js,jsx,ts,tsx}", "./public/index.html"],
+  corePlugins: {
+    preflight: false,
+  },
+  prefix: "",
+};

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "build", "public"]
+}


### PR DESCRIPTION
A TypeScript/React frontend for managing Archer resources (services,
endpoints, RBAC policies, agents) embedded as a juno micro-frontend.

Highlights:
- Service, endpoint, and RBAC list/detail/edit views with filtering, sorting,
  and pending-state polling backed by TanStack Query.
- Topology view (React Flow) that groups resources into Current Project,
  Managed Services, External Services, and External Consumers, with status-
  driven edges and an inspector panel.
- Foreign-service indicator in the service list ("External" badge) and
  per-service consumer panels for accept/reject of pending endpoints.
- Dark/light theme support across the topology view; status-change toasts
  with proper gating so endpoint updates don't trigger "accepted" toasts.
- Embeddable via mount(container, props) with mock-API support for local
  development.
