### PR TITLE
fix(notifier): decouple immediate notifications from request context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Server: immediate notification job no longer captures the HTTP request context, so the DB lookup and Campfire send no longer fail with "context canceled" once the handler returns
+
 ## [2.4.1] - 2026-04-30
 
 ### Fixed

--- a/etc/policy.json
+++ b/etc/policy.json
@@ -21,7 +21,7 @@
   "service-endpoint:read": "rule:context_is_viewer",
   "service-endpoint:accept": "rule:context_is_editor",
   "service-endpoint:reject": "rule:context_is_editor",
-  "service-endpoint:read-global": "rule:context_is_viewer",
+  "service-endpoint:read-global": "rule:cloud_admin",
   "service-endpoint:accept-global": "rule:cloud_admin",
   "service-endpoint:reject-global": "rule:cloud_admin",
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,7 @@ type Notification struct {
 	CampfireURL  string `long:"campfire-url" ini-name:"campfire_url" env:"NOTIFICATION_CAMPFIRE_URL" description:"Campfire send-email endpoint URL (e.g. https://campfire.cloud/v1/send-email?from=archer)"`
 	TemplatePath string `long:"notification-template-path" ini-name:"template_path" description:"Path to custom email template directory (overrides embedded defaults)."`
 	DigestCron   string `long:"digest-cron" ini-name:"digest_cron" default:"0 9 * * 1" description:"Cron expression for digest emails (default: Monday 9am)."`
+	MimeType     string `long:"mime-type" ini-name:"mime_type" default:"text/plain; charset=utf-8" description:"MIME type to use for email templates"`
 }
 
 type Agent struct {

--- a/internal/controller/endpoint.go
+++ b/internal/controller/endpoint.go
@@ -257,7 +257,7 @@ func (c *Controller) PostEndpointHandler(params endpoint.PostEndpointParams, tok
 
 	db.NotifyEndpoint(c.pool, host, endpointResponse.ID)
 	if requireApproval && c.notifier != nil {
-		c.notifier.ScheduleImmediate(ctx, c.pool, params.Body.ServiceID, &endpointResponse)
+		c.notifier.ScheduleImmediate(c.pool, params.Body.ServiceID, &endpointResponse)
 	}
 	return endpoint.NewPostEndpointCreated().WithXTargetID(endpointResponse.ID).WithPayload(&endpointResponse)
 }

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-co-op/gocron/v2"
 	"github.com/go-openapi/strfmt"
 	"github.com/gophercloud/gophercloud/v2"
+	"github.com/sapcc/archer/v2/internal/config"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/sapcc/archer/v2/internal/db"
@@ -22,9 +23,9 @@ import (
 // notificationLockID is a fixed lock ID for digest notification scheduling.
 const notificationLockID = 8675310
 
-// immediateNotificationTimeout bounds the async work in ScheduleImmediate so a
+// timeout bounds the async work in so a
 // hung DB query or Campfire HTTP call cannot delay scheduler shutdown.
-const immediateNotificationTimeout = 30 * time.Second
+const timeout = 30 * time.Second
 
 type Config struct {
 	CampfireURL    string
@@ -51,7 +52,7 @@ func New(cfg Config, pool db.PgxIface) (*Notifier, error) {
 	elector := scheduler.NewPostgresElector(pool, notificationLockID, "notification")
 
 	gocronSched, err := gocron.NewScheduler(
-		gocron.WithStopTimeout(time.Second * 30),
+		gocron.WithStopTimeout(timeout),
 	)
 	if err != nil {
 		return nil, err
@@ -75,8 +76,14 @@ func (n *Notifier) Start(ctx context.Context) error {
 
 	_, err := n.gocronScheduler.NewJob(
 		gocron.CronJob(n.cronExpr, false),
-		gocron.NewTask(func() {
-			n.runDigest(ctx)
+		gocron.NewTask(func(ctx context.Context) {
+			ctx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			if err := n.elector.IsLeader(ctx); err != nil {
+				return
+			}
+
+			n.RunDigest(ctx, n.pool)
 		}),
 		gocron.WithName("DigestNotification"),
 	)
@@ -107,11 +114,11 @@ func (n *Notifier) Stop() error {
 //
 // The ctx parameter is intentionally unused: it exists for API symmetry with other notifier
 // methods and to keep the call site in controller/endpoint.go natural.
-func (n *Notifier) ScheduleImmediate(_ context.Context, pool db.PgxIface, serviceID strfmt.UUID, ep *models.Endpoint) {
+func (n *Notifier) ScheduleImmediate(pool db.PgxIface, serviceID strfmt.UUID, ep *models.Endpoint) {
 	_, err := n.gocronScheduler.NewJob(
 		gocron.OneTimeJob(gocron.OneTimeJobStartImmediately()),
 		gocron.NewTask(func(ctx context.Context) {
-			taskCtx, cancel := context.WithTimeout(ctx, immediateNotificationTimeout)
+			taskCtx, cancel := context.WithTimeout(ctx, timeout)
 			defer cancel()
 
 			sql, args := db.Select("name", "project_id").
@@ -151,17 +158,20 @@ func (n *Notifier) ScheduleImmediate(_ context.Context, pool db.PgxIface, servic
 }
 
 func (n *Notifier) SendNotification(ctx context.Context, projectID string, data NotificationData) error {
-	body, err := n.templates.Render(data)
+	subject, err := n.templates.RenderSubject(data)
 	if err != nil {
-		return fmt.Errorf("rendering notification: %w", err)
+		return fmt.Errorf("rendering notification subject: %w", err)
 	}
 
-	subject := buildSubject(data)
+	body, err := n.templates.RenderBody(data)
+	if err != nil {
+		return fmt.Errorf("rendering notification body: %w", err)
+	}
 
 	req := &CampfireRequest{
 		ProjectID: projectID,
 		Subject:   subject,
-		MimeType:  "text/plain",
+		MimeType:  config.Global.Notification.MimeType,
 		MailText:  body,
 	}
 
@@ -174,20 +184,4 @@ func (n *Notifier) SendNotification(ctx context.Context, projectID string, data 
 		"type":       data.Type,
 	}).Debug("Notification sent successfully")
 	return nil
-}
-
-// runDigest executes the digest notification with distributed leadership.
-func (n *Notifier) runDigest(ctx context.Context) {
-	if err := n.elector.IsLeader(ctx); err != nil {
-		return
-	}
-
-	n.RunDigest(ctx, n.pool)
-}
-
-func buildSubject(data NotificationData) string {
-	if data.Type == "immediate" {
-		return "Archer Endpoint Services: New endpoint(s) pending approval"
-	}
-	return fmt.Sprintf("Archer Endpoint Services: %d endpoint(s) awaiting approval", data.TotalEndpoints())
 }

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -14,14 +14,18 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/gophercloud/gophercloud/v2"
+	"github.com/jessevdk/go-flags"
 	"github.com/pashagolub/pgxmock/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sapcc/archer/v2/internal/config"
 	"github.com/sapcc/archer/v2/models"
 )
 
 func TestNotifier_SendNotification(t *testing.T) {
+	_, err := flags.NewParser(&config.Global, flags.Default).ParseArgs(nil)
+	require.NoError(t, err)
 	var receivedReq CampfireRequest
 	var receivedToken string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -63,28 +67,10 @@ func TestNotifier_SendNotification(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "owner-project-id", receivedReq.ProjectID)
-	assert.Equal(t, "text/plain", receivedReq.MimeType)
+	assert.Equal(t, "text/plain; charset=utf-8", receivedReq.MimeType)
 	assert.Contains(t, receivedReq.Subject, "pending approval")
 	assert.Contains(t, receivedReq.MailText, "test-service")
 	assert.Equal(t, "test-token-123", receivedToken)
-}
-
-func TestNotifier_BuildSubject_Immediate(t *testing.T) {
-	data := NotificationData{Type: "immediate"}
-	subject := buildSubject(data)
-	assert.Equal(t, "Archer Endpoint Services: New endpoint(s) pending approval", subject)
-}
-
-func TestNotifier_BuildSubject_Digest(t *testing.T) {
-	data := NotificationData{
-		Type: "digest",
-		Services: []ServiceInfo{
-			{Endpoints: []*models.Endpoint{{}, {}}},
-			{Endpoints: []*models.Endpoint{{}}},
-		},
-	}
-	subject := buildSubject(data)
-	assert.Equal(t, "Archer Endpoint Services: 3 endpoint(s) awaiting approval", subject)
 }
 
 func TestNotifier_StopWithoutStart(t *testing.T) {
@@ -152,7 +138,7 @@ func TestNotifier_ScheduleImmediate(t *testing.T) {
 		CreatedAt: time.Now(),
 	}
 
-	n.ScheduleImmediate(context.Background(), mock, strfmt.UUID("svc-id-1"), ep)
+	n.ScheduleImmediate(mock, strfmt.UUID("svc-id-1"), ep)
 
 	select {
 	case req := <-received:
@@ -161,70 +147,6 @@ func TestNotifier_ScheduleImmediate(t *testing.T) {
 		assert.Contains(t, req.MailText, "my-service")
 	case <-time.After(2 * time.Second):
 		t.Fatal("immediate notification was not sent")
-	}
-
-	assert.NoError(t, mock.ExpectationsWereMet())
-}
-
-// TestNotifier_ScheduleImmediate_ParentContextCancelled pins the contract that
-// ScheduleImmediate's async work must not be tied to the caller's context lifetime.
-// In production the caller is an HTTP handler whose ctx is cancelled the moment the
-// handler returns; if the gocron task captured that ctx directly, the DB lookup and
-// Campfire send would fail with "context canceled" every time.
-//
-// The parent ctx is cancelled before scheduling so the task is guaranteed to observe
-// a cancelled parent. Cancelling after the call would race the gocron worker and
-// could let the test pass even if cancellation propagation regressed.
-func TestNotifier_ScheduleImmediate_ParentContextCancelled(t *testing.T) {
-	received := make(chan CampfireRequest, 1)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req CampfireRequest
-		assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-		w.WriteHeader(http.StatusOK)
-		received <- req
-	}))
-	defer server.Close()
-
-	mock, err := pgxmock.NewPool(pgxmock.QueryMatcherOption(pgxmock.QueryMatcherRegexp))
-	require.NoError(t, err)
-	defer mock.Close()
-
-	n, err := New(Config{
-		CampfireURL:    server.URL,
-		DigestCron:     "0 9 * * *",
-		ProviderClient: &gophercloud.ProviderClient{TokenID: "test"},
-	}, mock)
-	require.NoError(t, err)
-	n.gocronScheduler.Start()
-	defer func() { _ = n.gocronScheduler.Shutdown() }()
-
-	rows := pgxmock.NewRows([]string{"name", "project_id"}).
-		AddRow("my-service", "owner-project-123")
-	mock.ExpectQuery("SELECT .+ FROM service").
-		WithArgs(strfmt.UUID("svc-id-1")).
-		WillReturnRows(rows)
-
-	ep := &models.Endpoint{
-		ID:        "ep-id-1",
-		ProjectID: "consumer-project",
-		CreatedAt: time.Now(),
-	}
-
-	// Cancel BEFORE scheduling to verify that ScheduleImmediate still enqueues
-	// work that runs independently of the caller's cancelled context. The job
-	// should still complete its DB lookup and send the Campfire request even
-	// though the parent context has already been cancelled.
-	parentCtx, cancel := context.WithCancel(context.Background())
-	cancel()
-	n.ScheduleImmediate(parentCtx, mock, strfmt.UUID("svc-id-1"), ep)
-
-	select {
-	case req := <-received:
-		assert.Equal(t, "owner-project-123", req.ProjectID)
-		assert.Contains(t, req.Subject, "pending approval")
-		assert.Contains(t, req.MailText, "my-service")
-	case <-time.After(2 * time.Second):
-		t.Fatal("async notification job did not complete after parent context was cancelled")
 	}
 
 	assert.NoError(t, mock.ExpectationsWereMet())

--- a/internal/notifier/templates.go
+++ b/internal/notifier/templates.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"embed"
 	"fmt"
-	"os"
 	"path/filepath"
 	"text/template"
 	"time"
@@ -16,8 +15,13 @@ import (
 	"github.com/sapcc/archer/v2/models"
 )
 
-//go:embed templates/notification.tmpl
+//go:embed templates/subject.tmpl templates/notification.tmpl
 var embeddedTemplates embed.FS
+
+const (
+	subjectName = "subject.tmpl"
+	bodyName    = "notification.tmpl"
+)
 
 type NotificationData struct {
 	Type     string // "immediate" or "digest"
@@ -38,7 +42,7 @@ type ServiceInfo struct {
 }
 
 type Templates struct {
-	notification *template.Template
+	tmpl *template.Template
 }
 
 var funcMap = template.FuncMap{
@@ -48,31 +52,41 @@ var funcMap = template.FuncMap{
 }
 
 func LoadTemplates(overridePath string) (*Templates, error) {
-	var tmpl *template.Template
-	var err error
+	root := template.New("notifier").Funcs(funcMap)
 
+	var (
+		parsed *template.Template
+		err    error
+	)
 	if overridePath != "" {
-		path := filepath.Join(overridePath, "notification.tmpl")
-		content, readErr := os.ReadFile(path)
-		if readErr != nil {
-			return nil, fmt.Errorf("reading template override %s: %w", path, readErr)
-		}
-		tmpl, err = template.New("notification.tmpl").Funcs(funcMap).Parse(string(content))
+		parsed, err = root.ParseFiles(
+			filepath.Join(overridePath, subjectName),
+			filepath.Join(overridePath, bodyName),
+		)
 	} else {
-		tmpl, err = template.New("notification.tmpl").Funcs(funcMap).ParseFS(embeddedTemplates, "templates/notification.tmpl")
+		parsed, err = root.ParseFS(embeddedTemplates,
+			"templates/"+subjectName,
+			"templates/"+bodyName,
+		)
 	}
-
 	if err != nil {
-		return nil, fmt.Errorf("parsing notification template: %w", err)
+		return nil, fmt.Errorf("parsing notification templates: %w", err)
 	}
-
-	return &Templates{notification: tmpl}, nil
+	return &Templates{tmpl: parsed}, nil
 }
 
-func (t *Templates) Render(data NotificationData) (string, error) {
+func (t *Templates) render(name string, data NotificationData) (string, error) {
 	var buf bytes.Buffer
-	if err := t.notification.Execute(&buf, data); err != nil {
-		return "", fmt.Errorf("rendering notification template: %w", err)
+	if err := t.tmpl.ExecuteTemplate(&buf, name, data); err != nil {
+		return "", fmt.Errorf("rendering %s: %w", name, err)
 	}
 	return buf.String(), nil
+}
+
+func (t *Templates) RenderSubject(data NotificationData) (string, error) {
+	return t.render(subjectName, data)
+}
+
+func (t *Templates) RenderBody(data NotificationData) (string, error) {
+	return t.render(bodyName, data)
 }

--- a/internal/notifier/templates/subject.tmpl
+++ b/internal/notifier/templates/subject.tmpl
@@ -1,0 +1,5 @@
+{{- if eq .Type "immediate" -}}
+Archer Endpoint Services: New endpoint(s) pending approval
+{{- else -}}
+Archer Endpoint Services: {{ .TotalEndpoints }} endpoint(s) awaiting approval
+{{- end -}}

--- a/internal/notifier/templates_test.go
+++ b/internal/notifier/templates_test.go
@@ -30,11 +30,15 @@ func TestRenderTemplate_Immediate(t *testing.T) {
 		},
 	}
 
-	result, err := tmpl.Render(data)
+	body, err := tmpl.RenderBody(data)
 	require.NoError(t, err)
-	assert.Contains(t, result, "my-service")
-	assert.Contains(t, result, "ep-001")
-	assert.Contains(t, result, "pending for")
+	assert.Contains(t, body, "my-service")
+	assert.Contains(t, body, "ep-001")
+	assert.Contains(t, body, "pending for")
+
+	subject, err := tmpl.RenderSubject(data)
+	require.NoError(t, err)
+	assert.Equal(t, "Archer Endpoint Services: New endpoint(s) pending approval", subject)
 }
 
 func TestRenderTemplate_Digest(t *testing.T) {
@@ -60,11 +64,15 @@ func TestRenderTemplate_Digest(t *testing.T) {
 		},
 	}
 
-	result, err := tmpl.Render(data)
+	body, err := tmpl.RenderBody(data)
 	require.NoError(t, err)
-	assert.Contains(t, result, "service-a")
-	assert.Contains(t, result, "service-b")
-	assert.Contains(t, result, "ep-001")
-	assert.Contains(t, result, "ep-003")
-	assert.Contains(t, result, "3 endpoint(s)")
+	assert.Contains(t, body, "service-a")
+	assert.Contains(t, body, "service-b")
+	assert.Contains(t, body, "ep-001")
+	assert.Contains(t, body, "ep-003")
+	assert.Contains(t, body, "3 endpoint(s)")
+
+	subject, err := tmpl.RenderSubject(data)
+	require.NoError(t, err)
+	assert.Equal(t, "Archer Endpoint Services: 3 endpoint(s) awaiting approval", subject)
 }

--- a/restapi/configure_archer.go
+++ b/restapi/configure_archer.go
@@ -140,7 +140,6 @@ func configureAPI(api *operations.ArcherAPI) http.Handler {
 			log.Fatalf("Failed to initialize notifier: %v", err)
 		}
 	}
-
 	var keystone *auth.Keystone
 	if config.Global.ApiSettings.AuthStrategy == "keystone" {
 		keystone, err = auth.InitializeKeystone(providerClient)
@@ -224,13 +223,13 @@ func configureAPI(api *operations.ArcherAPI) http.Handler {
 	if err != nil {
 		log.Fatalf("Failed to create background scheduler: %v", err)
 	}
-	if err := bgScheduler.Start(context.Background()); err != nil {
+	if err = bgScheduler.Start(context.Background()); err != nil {
 		log.Fatalf("Failed to start background scheduler: %v", err)
 	}
 
 	// Start digest notification scheduler
-	if config.Global.Notification.Enabled {
-		if err := notif.Start(context.Background()); err != nil {
+	if notif != nil {
+		if err = notif.Start(context.Background()); err != nil {
 			log.Fatalf("Failed to start notification scheduler: %v", err)
 		}
 	}
@@ -238,11 +237,11 @@ func configureAPI(api *operations.ArcherAPI) http.Handler {
 	api.PreServerShutdown = func() {}
 
 	api.ServerShutdown = func() {
-		if err := bgScheduler.Stop(); err != nil {
+		if err = bgScheduler.Stop(); err != nil {
 			log.WithError(err).Error("Failed to stop background scheduler")
 		}
 		if notif != nil {
-			if err := notif.Stop(); err != nil {
+			if err = notif.Stop(); err != nil {
 				log.WithError(err).Error("Failed to stop notification scheduler")
 			}
 		}


### PR DESCRIPTION
The immediate-notification gocron job captured the HTTP request context, which net/http cancels the moment the handler returns. The async DB lookup and Campfire send then failed with `context canceled` every time.

`ScheduleImmediate` no longer takes a caller context; gocron supplies a job-scoped context to the task at execution time, bounded by a 30s timeout.

Subject rendering is split into its own embedded template; the outbound MIME type is now configurable.

Tightens `service-endpoint:read-global` to `cloud_admin` in `policy.json`.