### PR TITLE
fix(scheduler): recover leader election when dedicated conn dies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Server: immediate notification job no longer captures the HTTP request context, so the DB lookup and Campfire send no longer fail with "context canceled" once the handler returns
+- Scheduler: leader election now recovers when its dedicated PostgreSQL connection dies (server restart, proxy cycling, idle timeout) — previously the elector logged `failed to deallocate cached statement(s): conn closed` on every tick and the instance could never become leader again until restart
 
 ## [2.4.1] - 2026-04-30
 

--- a/internal/scheduler/elector.go
+++ b/internal/scheduler/elector.go
@@ -54,18 +54,39 @@ func (e *PostgresElector) Start(ctx context.Context) error {
 // Close releases the dedicated connection and any held advisory locks.
 func (e *PostgresElector) Close() {
 	if e.conn != nil {
-		// Explicitly release the advisory lock before releasing the connection
-		if e.isLeader {
+		// Explicitly release the advisory lock before releasing the connection.
+		// Skip if the underlying conn is already dead — Postgres has released the
+		// session-scoped lock for us and the Exec would just log a spurious error.
+		if e.isLeader && !e.conn.Conn().IsClosed() {
 			_, err := e.conn.Exec(context.Background(), "SELECT pg_advisory_unlock($1)", e.lockID)
 			if err != nil {
 				log.WithError(err).Error("Failed to release advisory lock")
 			}
-			e.isLeader = false
 		}
+		e.isLeader = false
 		e.conn.Release()
 		e.conn = nil
 		log.WithField("scheduler", e.name).Info("Released dedicated connection")
 	}
+}
+
+// reacquireConn replaces a dead dedicated connection with a fresh one from the pool.
+// Any advisory lock previously held on the old session is gone (Postgres releases
+// session-scoped locks when the session dies), so isLeader is reset to false.
+func (e *PostgresElector) reacquireConn(ctx context.Context) error {
+	if e.conn != nil {
+		e.conn.Release()
+		e.conn = nil
+	}
+	e.isLeader = false
+
+	conn, err := e.pool.Acquire(ctx)
+	if err != nil {
+		return err
+	}
+	e.conn = conn
+	log.WithField("scheduler", e.name).Warn("Reacquired dedicated connection after previous one closed")
+	return nil
 }
 
 // IsLeader implements gocron.Elector.
@@ -77,10 +98,29 @@ func (e *PostgresElector) IsLeader(ctx context.Context) error {
 		return errors.New("elector not started")
 	}
 
+	// If the dedicated conn died (Postgres restart, idle timeout, proxy cycling),
+	// pgx surfaces this as "conn closed" / "failed to deallocate cached statement(s)".
+	// Detect proactively and reacquire so leader election can recover without a process restart.
+	if e.conn.Conn().IsClosed() {
+		if err := e.reacquireConn(ctx); err != nil {
+			log.WithError(err).Error("Failed to reacquire dedicated connection for leader election")
+			return err
+		}
+	}
+
 	// Try to acquire the advisory lock (non-blocking)
 	var acquired bool
 	err := e.conn.QueryRow(ctx, "SELECT pg_try_advisory_lock($1)", e.lockID).Scan(&acquired)
 	if err != nil {
+		// Conn may have died mid-query; try to recover once so the next tick succeeds.
+		if e.conn.Conn().IsClosed() {
+			if rerr := e.reacquireConn(ctx); rerr != nil {
+				log.WithError(rerr).Error("Failed to reacquire dedicated connection for leader election")
+				return rerr
+			}
+			log.WithError(err).Warn("Advisory lock query failed on dead conn; reacquired, will retry next tick")
+			return ErrNotLeader
+		}
 		log.WithError(err).Error("Failed to check advisory lock for leader election")
 		return err
 	}

--- a/internal/scheduler/elector_integration_test.go
+++ b/internal/scheduler/elector_integration_test.go
@@ -162,6 +162,43 @@ func TestPostgresElector_Integration(t *testing.T) {
 		assert.True(t, isLeader1 != isLeader2, "Exactly one elector should be leader, got elector1=%v, elector2=%v", isLeader1, isLeader2)
 	})
 
+	t.Run("recovers when dedicated connection is killed", func(t *testing.T) {
+		pool, err := pgxpool.New(ctx, connStr)
+		require.NoError(t, err)
+		defer pool.Close()
+
+		elector := NewPostgresElector(pool, testLockID, "test")
+		require.NoError(t, elector.Start(ctx))
+		defer elector.Close()
+
+		// Become leader and capture the backend pid of the dedicated session.
+		require.NoError(t, elector.IsLeader(ctx))
+		require.True(t, elector.isLeader)
+
+		var pid int32
+		require.NoError(t, elector.conn.QueryRow(ctx, "SELECT pg_backend_pid()").Scan(&pid))
+
+		// Kill that backend from a separate connection. This simulates a Postgres
+		// restart / proxy cycling / idle timeout that drops the dedicated conn.
+		killConn, err := pool.Acquire(ctx)
+		require.NoError(t, err)
+		_, err = killConn.Exec(ctx, "SELECT pg_terminate_backend($1)", pid)
+		require.NoError(t, err)
+		killConn.Release()
+
+		// Next IsLeader call must recover (not return a permanent error).
+		// Either path is acceptable: it reacquires and immediately becomes leader
+		// (the lock is free again because the prior session died), or it bounces
+		// once with ErrNotLeader and succeeds on the following tick.
+		err = elector.IsLeader(ctx)
+		if err != nil {
+			assert.ErrorIs(t, err, ErrNotLeader, "post-kill error must be recoverable, got %v", err)
+			// Subsequent tick must succeed.
+			require.NoError(t, elector.IsLeader(ctx))
+		}
+		assert.True(t, elector.isLeader, "elector should be leader again after recovery")
+	})
+
 	t.Run("leadership stable across multiple checks", func(t *testing.T) {
 		pool, err := pgxpool.New(ctx, connStr)
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary
- The leader-election `PostgresElector` holds a single `pgxpool` connection for its session-scoped advisory lock. When that connection died (Postgres restart, proxy cycling, idle timeout), pgx kept surfacing `conn closed` / `failed to deallocate cached statement(s)` on every tick and the instance could never become leader again until process restart.
- Detect a closed conn before and after the advisory-lock query and reacquire a fresh one from the pool. The session-scoped lock is gone with the dead session, so `isLeader` is reset and the next tick races for the lock cleanly.
- Adds an integration test that captures the dedicated session's backend pid, kills it via `pg_terminate_backend` from a separate connection, and asserts the elector recovers leadership on the next tick or two.