### PR TITLE
ci(renovate): set 3-day minimumReleaseAge for npm packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -68,6 +68,12 @@
         "github.com/getsentry/sentry-go"
       ],
       "allowedVersions": "v0.20.0"
+    },
+    {
+      "matchFileNames": [
+        "web/**"
+      ],
+      "minimumReleaseAge": "3 days"
     }
   ],
   "prHourlyLimit": 0,

--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -65,6 +65,8 @@ renovate:
   packageRules:
     - matchPackageNames: [ "github.com/getsentry/sentry-go" ]
       allowedVersions: v0.20.0
+    - matchFileNames: [ "web/**" ]
+      minimumReleaseAge: "3 days"
 
 reuse:
   annotations:


### PR DESCRIPTION
- Adds a Renovate package rule that delays npm dependency PRs until the new version has been published for at least 3 days.
- Scoped via `matchFileNames: web/**` (the only npm code in the repo) since `go-makefile-maker` does not support `matchManagers` in `packageRules`.
- Source of truth lives in `Makefile.maker.yaml`; `.github/renovate.json` is updated in lockstep so the rule is active before the next regeneration.