### PR TITLE
web: drop postcss-url and the minimatch override

### DIFF
--- a/web/esbuild.config.js
+++ b/web/esbuild.config.js
@@ -7,7 +7,6 @@ const pkg = require("./package.json");
 const postcss = require("postcss");
 const sass = require("sass");
 const { transform } = require("@svgr/core");
-const url = require("postcss-url");
 const tailwindcss = require("@tailwindcss/postcss");
 const autoprefixer = require("autoprefixer");
 
@@ -98,18 +97,7 @@ const build = async () => {
       {
         name: "parse-styles",
         setup(build) {
-          const postcssProcessor = postcss([
-            tailwindcss,
-            autoprefixer,
-            url({
-              url: "inline",
-              maxSize: 10,
-              fallback: "copy",
-              assetsPath: "./build/assets",
-              useHash: true,
-              optimizeSvgEncode: true,
-            }),
-          ]);
+          const postcssProcessor = postcss([tailwindcss, autoprefixer]);
 
           build.onLoad(
             { filter: /.\.(css|scss)$/, namespace: "file" },

--- a/web/package.json
+++ b/web/package.json
@@ -23,7 +23,6 @@
     "@types/react-dom": "^19.0.0",
     "autoprefixer": "^10.4.2",
     "postcss": "^8.4.21",
-    "postcss-url": "^10.1.3",
     "prettier": "^3.2.5",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  minimatch@<3.1.4: ^10.0.0
-
 importers:
 
   .:
@@ -51,9 +48,6 @@ importers:
       postcss:
         specifier: ^8.4.21
         version: 8.5.14
-      postcss-url:
-        specifier: ^10.1.3
-        version: 10.1.3(postcss@8.5.14)
       prettier:
         specifier: ^3.2.5
         version: 3.8.3
@@ -697,18 +691,10 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
-  balanced-match@4.0.4:
-    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
-    engines: {node: 18 || 20 || >=22}
-
   baseline-browser-mapping@2.10.30:
     resolution: {integrity: sha512-xjOFN16Ha1+Rz4nFYKqHU/LSB+gx/Vi3yQLX7r7sAW+Wa+8hhF2h4pvqTrTMc8+WcDBEunnUurr46Jvv0jk3Vg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -766,9 +752,6 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
-
-  cuint@0.2.2:
-    resolution: {integrity: sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw==}
 
   d3-color@3.1.0:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
@@ -1015,19 +998,6 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  make-dir@3.1.0:
-    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
-    engines: {node: '>=8'}
-
-  mime@2.5.2:
-    resolution: {integrity: sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==}
-    engines: {node: '>=4.0.0'}
-    hasBin: true
-
-  minimatch@10.2.5:
-    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
-    engines: {node: 18 || 20 || >=22}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1083,12 +1053,6 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
-
-  postcss-url@10.1.3:
-    resolution: {integrity: sha512-FUzyxfI5l2tKmXdYc6VTu3TWZsInayEKPbiyW+P6vmmIrrb4I6CGX0BFoewgYHLK+oIL5FECEK02REYRpBvUCw==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      postcss: ^8.0.0
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -1237,9 +1201,6 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
-
-  xxhashjs@0.2.2:
-    resolution: {integrity: sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -1828,13 +1789,7 @@ snapshots:
       postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  balanced-match@4.0.4: {}
-
   baseline-browser-mapping@2.10.30: {}
-
-  brace-expansion@5.0.6:
-    dependencies:
-      balanced-match: 4.0.4
 
   browserslist@4.28.2:
     dependencies:
@@ -1884,8 +1839,6 @@ snapshots:
       typescript: 6.0.3
 
   csstype@3.2.3: {}
-
-  cuint@0.2.2: {}
 
   d3-color@3.1.0: {}
 
@@ -2103,16 +2056,6 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  make-dir@3.1.0:
-    dependencies:
-      semver: 6.3.1
-
-  mime@2.5.2: {}
-
-  minimatch@10.2.5:
-    dependencies:
-      brace-expansion: 5.0.6
-
   ms@2.1.3: {}
 
   msw@2.14.6(@types/node@25.9.0)(typescript@6.0.3):
@@ -2175,14 +2118,6 @@ snapshots:
 
   picomatch@4.0.4:
     optional: true
-
-  postcss-url@10.1.3(postcss@8.5.14):
-    dependencies:
-      make-dir: 3.1.0
-      mime: 2.5.2
-      minimatch: 10.2.5
-      postcss: 8.5.14
-      xxhashjs: 0.2.2
 
   postcss-value-parser@4.2.0: {}
 
@@ -2301,10 +2236,6 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-
-  xxhashjs@0.2.2:
-    dependencies:
-      cuint: 0.2.2
 
   y18n@5.0.8: {}
 

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -2,7 +2,3 @@ allowBuilds:
   '@parcel/watcher': true
   esbuild: true
   msw: true
-minimumReleaseAgeExclude:
-  - minimatch@3.1.4
-overrides:
-  minimatch@<3.1.4: ^10.0.0


### PR DESCRIPTION
The postcss-url plugin in esbuild.config.js was configured to inline/copy CSS asset references, but no source CSS in the project contains external url() refs - and neither do the imported juno-ui-components / @xyflow/react stylesheets, where all SVGs are already pre-encoded data URIs. A production build never produced anything in build/assets/, confirming the plugin was effectively a no-op.

Dropping it lets us also remove the minimatch@<3.1.4 workspace override (PR #784) - postcss-url was the only consumer pulling in a vulnerable minimatch range, so once it's gone the override has no purpose.

Verified locally: pnpm install removes 9 packages (postcss-url + transitives including minimatch), pnpm typecheck / build / audit all pass, and the dev server renders the Topology and Services tabs identically with no console errors.