### PR TITLE
ci(release): draft GitHub Release on merge instead of pushing tag

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: Create Release Tag
+name: Release - Draft GitHub Release
 
 on:
   pull_request:
@@ -10,8 +10,8 @@ on:
     branches: [main]
 
 jobs:
-  create-tag:
-    name: Create release tag
+  draft-release:
+    name: Draft GitHub Release
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'chore/release-next'
     permissions:
@@ -28,17 +28,18 @@ jobs:
           command: query
           version: latest
 
-      - name: Create annotated tag
+      - name: Create draft GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: v${{ steps.version.outputs.version }}
+          RELEASE_NOTES: ${{ steps.version.outputs.release-notes }}
         run: |
-          VERSION="v${{ steps.version.outputs.version }}"
-          git config user.name "GitHub Actions"
-          git config user.email "actions@github.com"
-
-          # Check if tag already exists
-          if git rev-parse "${VERSION}" >/dev/null 2>&1; then
-            echo "Tag ${VERSION} already exists, skipping"
+          if gh release view "${VERSION}" >/dev/null 2>&1; then
+            echo "Release ${VERSION} already exists, skipping"
             exit 0
           fi
 
-          git tag -a "${VERSION}" -m "Release ${VERSION}"
-          git push origin "${VERSION}"
+          gh release create "${VERSION}" \
+            --draft \
+            --title "${VERSION}" \
+            --notes "${RELEASE_NOTES}"

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: Draft Release
+name: Release - Open PR
 
 on:
   push:
@@ -105,5 +105,5 @@ jobs:
 
             ---
 
-            Merging this PR will automatically create an annotated tag `v${{ steps.bump.outputs.version }}` on main.
+            Merging this PR will automatically create a **draft** GitHub Release `v${{ steps.bump.outputs.version }}`. Publish that release from the GitHub UI to create the tag and trigger goreleaser.
           labels: release


### PR DESCRIPTION
Tags pushed by `GITHUB_TOKEN` don't trigger `on: push: tags` workflows, so `goreleaser.yaml` (and any other tag-driven action) never fired when the previous workflow auto-pushed the release tag.

This switches the post-merge step to create a **draft** GitHub Release named `v<version>` with the changelog notes for that version. Publishing the draft from the GitHub UI creates the tag at main's HEAD via a real user action, which fires goreleaser normally — no PAT or app token needed, and you get a manual checkpoint between merging the release PR and shipping.

Also renames both release workflows to make the two-stage flow obvious:
- `draft-release.yml` → `release-pr.yml` (opens the version-bump PR)
- `create-release-tag.yml` → `release-draft.yml` (drafts the GitHub Release on merge)