### PR TITLE
Default SNAT pool size to 1 for all F5 services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,8 @@ build/
 
 *.ini
 
+# Generated API documentation (produced by `make markdown`)
+/docs/api.md
+
 # Claude Code user-specific settings
 .claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Service: F5/tenant services now always allocate a dedicated Neutron SNAT port pool. The `snat_pool_size` field defaults to 1 and is no longer optional in storage. **Upgrade impact:** existing services that previously used per-device SelfIP addresses for SNAT will be reallocated dedicated SNAT ports on the next agent sync. In-flight connections through the old SNAT addresses will be reset.
+
 ### Fixed
 
 - Server: immediate notification job no longer captures the HTTP request context, so the DB lookup and Campfire send no longer fail with "context canceled" once the handler returns
@@ -20,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Service: optional `snat_pool_size` field to scale outbound SNAT capacity (f5 provider only). When set, the controller allocates service-scoped Neutron ports synchronously on create/update; when unset, the existing per-device SelfIP path is used unchanged.
+- Service: `snat_pool_size` field on services to scale outbound SNAT capacity (f5 provider only, range 1-8, default 1). The controller allocates service-scoped Neutron ports synchronously on create/update.
 - ArcherUI: a TypeScript/React frontend for managing services, endpoints, and RBAC policies, with a topology view that visualizes the relationships between services, endpoints, and external consumers
 
 ### Added

--- a/internal/agent/f5/cleanup.go
+++ b/internal/agent/f5/cleanup.go
@@ -51,6 +51,10 @@ func (a *Agent) cleanupL2(ctx context.Context) error {
 		log.WithError(err).Error("cleanOrphanedNeutronPorts")
 		// continue
 	}
+	if err := a.cleanOrphanedSnatPorts(ctx); err != nil {
+		log.WithError(err).Error("cleanOrphanedSnatPorts")
+		// continue
+	}
 	return nil
 }
 
@@ -250,6 +254,63 @@ func (a *Agent) cleanOrphanedNeutronPorts(ctx context.Context, usedSegments map[
 	}
 
 	log.Debug("Finished cleanOrphanedNeutronPorts")
+	return nil
+}
+
+// cleanOrphanedSnatPorts deletes SNAT pool ports whose owning service no longer
+// exists in the DB on this host. SNAT ports are normally cleaned up by the
+// PENDING_DELETE branch of ProcessServices via CleanupServiceSnatPorts; this
+// catches the leftover cases — e.g. a row removed without going through that
+// flow, or a CleanupServiceSnatPorts that errored after the row was gone.
+//
+// The orphan signal here is per-service (device_id), not per-segment as for
+// SelfIPs, because SNAT pools are owned by a single service rather than shared
+// across a subnet.
+func (a *Agent) cleanOrphanedSnatPorts(ctx context.Context) error {
+	log.Debug("Running cleanOrphanedSnatPorts")
+
+	snats, err := a.neutron.FetchSnatPorts(ctx)
+	if err != nil {
+		return err
+	}
+	if len(snats) == 0 {
+		log.Debug("Finished cleanOrphanedSnatPorts (no ports)")
+		return nil
+	}
+
+	sql, args := db.Select("id").From("service").
+		Where("host = ?", config.Global.Default.Host).
+		Where("provider = ?", models.ServiceProviderTenant).
+		MustSql()
+	rows, err := a.pool.Query(ctx, sql, args...)
+	if err != nil {
+		return fmt.Errorf("cleanOrphanedSnatPorts: list services: %w", err)
+	}
+	defer rows.Close()
+	live := make(map[string]struct{})
+	for rows.Next() {
+		var id strfmt.UUID
+		if err := rows.Scan(&id); err != nil {
+			return fmt.Errorf("cleanOrphanedSnatPorts: scan: %w", err)
+		}
+		live[id.String()] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("cleanOrphanedSnatPorts: rows: %w", err)
+	}
+
+	for _, port := range snats {
+		if _, ok := live[port.DeviceID]; ok {
+			continue // service still exists, port is live
+		}
+		log.WithFields(log.Fields{"port": port.ID, "service": port.DeviceID}).
+			Warningf("found orphan SNAT port '%s', deleting", port.Name)
+		if err := a.neutron.DeletePort(ctx, port.ID); err != nil {
+			log.Errorf("cleanOrphanedSnatPorts: %s", err.Error())
+		}
+	}
+
+	log.Debug("Finished cleanOrphanedSnatPorts")
 	return nil
 }
 

--- a/internal/agent/f5/cleanup_test.go
+++ b/internal/agent/f5/cleanup_test.go
@@ -133,6 +133,59 @@ func TestAgent_TestCleanOrphanedNeutronPorts(t *testing.T) {
 	assert.Nil(t, a.cleanOrphanedNeutronPorts(t.Context(), usedSegments))
 }
 
+// TestAgent_TestCleanOrphanedSnatPorts verifies that SNAT ports whose owning
+// service is no longer in the DB on this host are deleted, while ports for
+// live services are preserved.
+func TestAgent_TestCleanOrphanedSnatPorts(t *testing.T) {
+	const liveSvc = "11111111-1111-4111-8111-111111111111"
+	const orphanSvc = "22222222-2222-4222-8222-222222222222"
+
+	listResp := `{
+		"ports": [
+			{
+				"id": "live-port-id",
+				"name": "snat-` + liveSvc + `-0",
+				"device_owner": "network:f5snat",
+				"device_id": "` + liveSvc + `",
+				"network_id": "n0"
+			},
+			{
+				"id": "orphan-port-id",
+				"name": "snat-` + orphanSvc + `-0",
+				"device_owner": "network:f5snat",
+				"device_id": "` + orphanSvc + `",
+				"network_id": "n0"
+			}
+		]
+	}`
+
+	config.Global.Default.Host = "host-123"
+
+	fakeServer := th.SetupPersistentPortHTTP(t, 8931)
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, "/v2.0/ports", "GET", "", listResp, http.StatusOK)
+	fixture.SetupHandler(t, fakeServer, "/v2.0/ports/orphan-port-id", "DELETE",
+		"", "", http.StatusNoContent)
+
+	dbMock, err := pgxmock.NewPool(pgxmock.QueryMatcherOption(pgxmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbMock.Close()
+	dbMock.ExpectQuery("SELECT id FROM service WHERE host = $1 AND provider = $2").
+		WithArgs(config.Global.Default.Host, models.ServiceProviderTenant).
+		WillReturnRows(dbMock.NewRows([]string{"id"}).AddRow(liveSvc))
+
+	neutronClient := neutron.NeutronClient{ServiceClient: fake.ServiceClient(fakeServer)}
+	neutronClient.InitCache()
+	a := &Agent{neutron: &neutronClient, pool: dbMock}
+
+	assert.Nil(t, a.cleanOrphanedSnatPorts(t.Context()))
+	if err := dbMock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
 func TestAgent_TestCleanupOrphanedTenants(t *testing.T) {
 	f5DeviceMock := NewMockF5Device(t)
 	f5DeviceMock.On("GetHostname").Return("host-123")

--- a/internal/agent/f5/services.go
+++ b/internal/agent/f5/services.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/georgysavva/scany/v2/pgxscan"
 	"github.com/gophercloud/gophercloud/v2"
-	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/ports"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/subnets"
 	log "github.com/sirupsen/logrus"
 
@@ -27,7 +26,6 @@ import (
 func (a *Agent) getExtendedService(ctx context.Context, s *models.Service) (*as3.ExtendedService, error) {
 	// Fetch SNAT ports from neutron
 	service := &as3.ExtendedService{Service: *s}
-	deviceIDs := a.getDeviceIDs()
 	pendingDelete := service.Status == models.ServiceStatusPENDINGDELETE
 
 	network, err := a.neutron.GetNetwork(ctx, service.NetworkID.String())
@@ -45,22 +43,9 @@ func (a *Agent) getExtendedService(ctx context.Context, s *models.Service) (*as3
 		return nil, fmt.Errorf("GetNetwork: %w", internal.ErrNoSubnetFound)
 	}
 
-	// allocate picks between service-scoped SNAT ports (snat_pool_size set) and per-device
-	// SelfIP ports. The two paths share identical 409/quota handling below, so the only thing
-	// that varies per subnet is which Neutron helper to call and the error label used in wraps.
-	allocate := func(subnetID string) (map[string]*ports.Port, string, error) {
-		if service.SnatPoolSize != nil {
-			ports, err := a.neutron.EnsureServiceSnatPorts(ctx,
-				service.ID, subnetID, int(*service.SnatPoolSize), pendingDelete)
-			return ports, "EnsureServiceSnatPorts", err
-		}
-		ports, err := a.neutron.EnsureNeutronSelfIPs(ctx, deviceIDs, subnetID, pendingDelete)
-		return ports, "EnsureNeutronSelfIPs", err
-	}
-
-	// Try to allocate SNAT ports from the subnet that has the service in it
+	// Try to allocate SNAT ports from the subnet that has the service in it.
+	// Sized by snat_pool_size (default 1).
 	err = nil
-	var label string
 	for i, subnetID := range network.Subnets {
 		var subnet *subnets.Subnet
 		if subnet, err = a.neutron.GetSubnet(ctx, subnetID); err != nil {
@@ -93,7 +78,8 @@ func (a *Agent) getExtendedService(ctx context.Context, s *models.Service) (*as3
 			continue
 		}
 
-		service.NeutronPorts, label, err = allocate(subnetID)
+		service.NeutronPorts, err = a.neutron.EnsureServiceSnatPorts(ctx,
+			service.ID, subnetID, int(*service.SnatPoolSize), pendingDelete)
 		if err == nil {
 			service.SubnetID = subnetID
 			break
@@ -101,18 +87,18 @@ func (a *Agent) getExtendedService(ctx context.Context, s *models.Service) (*as3
 
 		if gerr, ok := errors.AsType[gophercloud.ErrUnexpectedResponseCode](err); ok && gerr.Actual == 409 {
 			if bytes.Contains(gerr.Body, []byte("OverQuota")) {
-				return nil, fmt.Errorf("%s: %w, %w", label, err, internal.ErrQuotaExceeded)
+				return nil, fmt.Errorf("EnsureServiceSnatPorts: %w, %w", err, internal.ErrQuotaExceeded)
 			} else if bytes.Contains(gerr.Body, []byte("No more IP addresses available")) {
 				continue // try next subnet
 			}
 		}
 
 		// unexpected error from neutron
-		return nil, fmt.Errorf("%s: %w", label, err)
+		return nil, fmt.Errorf("EnsureServiceSnatPorts: %w", err)
 	}
 	if err != nil || service.SubnetID == "" {
 		// All subnet IPs are exhausted
-		return nil, fmt.Errorf("%s: %w, %w", label, err, internal.ErrNoIPsAvailable)
+		return nil, fmt.Errorf("EnsureServiceSnatPorts: %w, %w", err, internal.ErrNoIPsAvailable)
 	}
 
 	// Fetch segmentID for the network
@@ -255,13 +241,12 @@ func (a *Agent) ProcessServices(ctx context.Context) error {
 				}
 			}
 
-			// Delete service-scoped SNAT ports if the service uses them. Independent of the
-			// L2/SelfIP cleanup gating because these ports belong to the service, not the
-			// shared subnet pool.
-			if service.SnatPoolSize != nil {
-				if err = a.neutron.CleanupServiceSnatPorts(ctx, service.ID); err != nil {
-					return fmt.Errorf("CleanupServiceSnatPorts: %w", err)
-				}
+			// Delete service-scoped SNAT ports. Independent of the L2/SelfIP
+			// cleanup gating because these ports belong to the service, not the
+			// shared subnet pool. CleanupServiceSnatPorts is idempotent, so a
+			// missing pool is a no-op.
+			if err = a.neutron.CleanupServiceSnatPorts(ctx, service.ID); err != nil {
+				return fmt.Errorf("CleanupServiceSnatPorts: %w", err)
 			}
 
 			if cleanupL2 {

--- a/internal/agent/f5/services_test.go
+++ b/internal/agent/f5/services_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag/conv"
 	fake "github.com/gophercloud/gophercloud/v2/openstack/networking/v2/common"
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 	"github.com/gophercloud/gophercloud/v2/testhelper/fixture"
@@ -64,7 +65,9 @@ func TestProcessServicesWithDeletedNetwork(t *testing.T) {
 	}()
 
 	f5DeviceHost := NewMockF5Device(t)
-	f5DeviceHost.On("GetHostname").Return("dummybigiphost")
+	// GetHostname is no longer called from getExtendedService (the SelfIP-as-
+	// SNAT branch was removed); the early-return path here doesn't reach any
+	// other caller.
 
 	config.Global.Default.Host = "host-123"
 	neutronClient := neutron.NeutronClient{ServiceClient: fake.ServiceClient(fakeServer)}
@@ -97,5 +100,95 @@ func TestProcessServicesWithDeletedNetwork(t *testing.T) {
 	}
 	if err := dbMock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
+// TestGetExtendedServiceAllocatesSnatPortsByDefault verifies that
+// getExtendedService routes every service through the dedicated SNAT pool
+// path (network:f5snat ports) and never reuses SelfIPs as SNAT. The previous
+// branch on SnatPoolSize == nil is gone — the field is now mandatory at the
+// model layer.
+func TestGetExtendedServiceAllocatesSnatPortsByDefault(t *testing.T) {
+	const networkID = "35a3ca82-62af-4e0a-9472-92331500fb3a"
+	const subnetID = "e0e0e0e0-e0e0-4e0e-8e0e-0e0e0e0e0e0e"
+	serviceID := strfmt.UUID("2975c302-4a0d-47ab-82df-42e7597ae41f")
+
+	fakeServer := th.SetupPersistentPortHTTP(t, 8931)
+	defer fakeServer.Teardown()
+	config.Global.Agent.PhysicalNetwork = "physnet1"
+	config.Global.Default.Host = "host-snat"
+
+	fixture.SetupHandler(t, fakeServer, "/v2.0/networks/"+networkID, "GET",
+		"", GetNetworkResponseFixture, http.StatusOK)
+	fixture.SetupHandler(t, fakeServer, "/v2.0/subnets/"+subnetID, "GET",
+		"", GetSubnetResponseFixture, http.StatusOK)
+
+	// Track which Neutron port flows are exercised. Listing on f5snat is
+	// expected (EnsureServiceSnatPorts); listing on f5selfip would mean the
+	// removed legacy branch is still being taken.
+	var (
+		snatList    int
+		selfipList  int
+		createCalls int
+	)
+	fakeServer.Mux.HandleFunc("/v2.0/ports", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			q := r.URL.Query()
+			switch q.Get("device_owner") {
+			case "network:f5snat":
+				snatList++
+			case "network:f5selfip":
+				selfipList++
+			}
+			_, _ = w.Write([]byte(`{"ports": []}`))
+		case http.MethodPost:
+			createCalls++
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"port": {
+				"id": "p0p0p0p0-p0p0-4p0p-8p0p-0p0p0p0p0p0p",
+				"name": "snat-` + serviceID.String() + `-0",
+				"device_owner": "network:f5snat",
+				"device_id": "` + serviceID.String() + `",
+				"network_id": "` + networkID + `",
+				"fixed_ips": [{"subnet_id": "` + subnetID + `", "ip_address": "192.0.0.10"}]
+			}}`))
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+
+	neutronClient := neutron.NeutronClient{ServiceClient: fake.ServiceClient(fakeServer)}
+	neutronClient.InitCache()
+	a := &Agent{neutron: &neutronClient}
+
+	netUUID := strfmt.UUID(networkID)
+	svc := &models.Service{
+		ID:           serviceID,
+		NetworkID:    &netUUID,
+		IPAddresses:  []models.InetAddress{"192.0.0.5/32"},
+		Status:       models.ServiceStatusPENDINGCREATE,
+		SnatPoolSize: conv.Pointer(int32(1)),
+	}
+
+	got, err := a.getExtendedService(context.Background(), svc)
+	if err != nil {
+		t.Fatalf("getExtendedService() error = %v", err)
+	}
+	if got.SubnetID != subnetID {
+		t.Errorf("expected SubnetID %s, got %s", subnetID, got.SubnetID)
+	}
+	if len(got.NeutronPorts) != 1 {
+		t.Fatalf("expected 1 SNAT port, got %d", len(got.NeutronPorts))
+	}
+	if snatList == 0 {
+		t.Error("expected at least one list of network:f5snat ports")
+	}
+	if selfipList != 0 {
+		t.Errorf("expected zero lists of network:f5selfip from getExtendedService SNAT path, got %d", selfipList)
+	}
+	if createCalls != 1 {
+		t.Errorf("expected one Neutron port to be created, got %d", createCalls)
 	}
 }

--- a/internal/controller/service.go
+++ b/internal/controller/service.go
@@ -245,6 +245,15 @@ func (c *Controller) PostServiceHandler(params service.PostServiceParams, princi
 			}
 		}
 
+		// When the client didn't supply snat_pool_size, bind the literal SQL
+		// DEFAULT keyword so the column's DB DEFAULT (1) applies. A nil bind
+		// would emit SQL NULL, which violates the NOT NULL constraint
+		// (DEFAULT only fires when the column is absent or DEFAULT is bound,
+		// not when NULL is bound).
+		var snatPoolSize any = sq.Expr("DEFAULT")
+		if params.Body.SnatPoolSize != nil {
+			snatPoolSize = *params.Body.SnatPoolSize
+		}
 		sql, args, err = db.Insert("service").
 			Columns("enabled", "name", "description", "network_id", "ip_addresses", "require_approval",
 				"visibility", "availability_zone", "proxy_protocol", "project_id", "ports", "tags", "provider", "host",
@@ -253,7 +262,7 @@ func (c *Controller) PostServiceHandler(params service.PostServiceParams, princi
 				params.Body.IPAddresses, params.Body.RequireApproval, params.Body.Visibility,
 				params.Body.AvailabilityZone, params.Body.ProxyProtocol, params.Body.ProjectID,
 				params.Body.Ports, internal.Unique(params.Body.Tags), params.Body.Provider, params.Body.Host,
-				params.Body.Protocol, params.Body.SnatPoolSize).
+				params.Body.Protocol, snatPoolSize).
 			Suffix("RETURNING *").ToSql()
 		if err != nil {
 			return err

--- a/internal/controller/service_test.go
+++ b/internal/controller/service_test.go
@@ -1220,3 +1220,82 @@ func (t *SuiteTest) TestServiceUpdateWithInvalidIPReturns400() {
 	assert.IsType(t.T(), &service.PutServiceServiceIDBadRequest{}, res)
 	assert.Contains(t.T(), res.(*service.PutServiceServiceIDBadRequest).Payload.Message, "invalid IP address")
 }
+
+// TestServicePostSnatPoolSizeDefault verifies that POST without snat_pool_size
+// stores 1 (the DB default) regardless of provider.
+func (t *SuiteTest) TestServicePostSnatPoolSizeDefault() {
+	serviceID := t.createService(testService)
+
+	res := t.c.GetServiceServiceIDHandler(
+		service.GetServiceServiceIDParams{HTTPRequest: &http.Request{}, ServiceID: serviceID},
+		nil)
+	assert.IsType(t.T(), &service.GetServiceServiceIDOK{}, res)
+	payload := res.(*service.GetServiceServiceIDOK).Payload
+	if assert.NotNil(t.T(), payload.SnatPoolSize) {
+		assert.Equal(t.T(), int32(1), *payload.SnatPoolSize)
+	}
+}
+
+// TestServicePostSnatPoolSizeExplicit verifies that a client-supplied value is
+// preserved as-is.
+func (t *SuiteTest) TestServicePostSnatPoolSizeExplicit() {
+	svc := testService
+	svc.SnatPoolSize = conv.Pointer(int32(5))
+	serviceID := t.createService(svc)
+
+	res := t.c.GetServiceServiceIDHandler(
+		service.GetServiceServiceIDParams{HTTPRequest: &http.Request{}, ServiceID: serviceID},
+		nil)
+	assert.IsType(t.T(), &service.GetServiceServiceIDOK{}, res)
+	payload := res.(*service.GetServiceServiceIDOK).Payload
+	if assert.NotNil(t.T(), payload.SnatPoolSize) {
+		assert.Equal(t.T(), int32(5), *payload.SnatPoolSize)
+	}
+}
+
+// TestServicePostSnatPoolSizeRejectedForCP verifies that a client-supplied
+// snat_pool_size is rejected for non-tenant providers.
+func (t *SuiteTest) TestServicePostSnatPoolSizeRejectedForCP() {
+	t.addCPAgent("cp-test-host", nil)
+
+	cpProvider := "cp"
+	svc := models.Service{
+		Name:         "cp-snat-rejected",
+		Provider:     &cpProvider,
+		IPAddresses:  []models.InetAddress{"192.168.1.101"},
+		Ports:        []int32{8080},
+		ProjectID:    testProject1,
+		SnatPoolSize: conv.Pointer(int32(3)),
+	}
+
+	res := t.c.PostServiceHandler(service.PostServiceParams{HTTPRequest: &headerProject1, Body: &svc},
+		&gopherpolicy.Token{Enforcer: &TestEnforcerAllowProvider{}})
+
+	assert.IsType(t.T(), &service.PostServiceUnprocessableEntity{}, res)
+	assert.Equal(t.T(), "snat_pool_size is only supported for provider=f5",
+		res.(*service.PostServiceUnprocessableEntity).Payload.Message)
+}
+
+// TestServicePostSnatPoolSizeCPDefault verifies that a CP service created
+// without snat_pool_size gets the inert DB default 1 stored, since the column
+// is NOT NULL.
+func (t *SuiteTest) TestServicePostSnatPoolSizeCPDefault() {
+	t.addCPAgent("cp-test-host", nil)
+
+	cpProvider := "cp"
+	svc := models.Service{
+		Name:        "cp-snat-default",
+		Provider:    &cpProvider,
+		IPAddresses: []models.InetAddress{"192.168.1.102"},
+		Ports:       []int32{8080},
+		ProjectID:   testProject1,
+	}
+
+	res := t.c.PostServiceHandler(service.PostServiceParams{HTTPRequest: &headerProject1, Body: &svc},
+		&gopherpolicy.Token{Enforcer: &TestEnforcerAllowProvider{}})
+	assert.IsType(t.T(), &service.PostServiceCreated{}, res)
+	payload := res.(*service.PostServiceCreated).Payload
+	if assert.NotNil(t.T(), payload.SnatPoolSize) {
+		assert.Equal(t.T(), int32(1), *payload.SnatPoolSize)
+	}
+}

--- a/internal/db/migrations/migration.go
+++ b/internal/db/migrations/migration.go
@@ -346,4 +346,18 @@ var Migrations = mgx.Migrations(
 		`)
 		return err
 	}),
+	mgx.NewMigration("default_snat_pool_size", func(ctx context.Context, commands mgx.Commands) error {
+		// Make every service own a dedicated SNAT pool. Existing non-NULL
+		// values (e.g. an operator who already set snat_pool_size = 3) are
+		// preserved; only NULL rows are backfilled to 1.
+		_, err := commands.Exec(ctx, `
+			UPDATE service SET snat_pool_size = 1 WHERE snat_pool_size IS NULL;
+			ALTER TABLE service ALTER COLUMN snat_pool_size SET NOT NULL;
+			ALTER TABLE service ALTER COLUMN snat_pool_size SET DEFAULT 1;
+			ALTER TABLE service DROP CONSTRAINT snat_pool_size;
+			ALTER TABLE service ADD CONSTRAINT snat_pool_size
+				CHECK (snat_pool_size BETWEEN 1 AND 8);
+		`)
+		return err
+	}),
 )

--- a/internal/neutron/snat_pool.go
+++ b/internal/neutron/snat_pool.go
@@ -68,3 +68,22 @@ func (n *NeutronClient) CleanupServiceSnatPorts(ctx context.Context, serviceID s
 	}
 	return nil
 }
+
+// FetchSnatPorts lists every SNAT pool port bound to this agent's host. Returns
+// a flat slice (not grouped) because the orphan signal for SNAT ports is
+// per-service (device_id) rather than per-segment.
+func (n *NeutronClient) FetchSnatPorts(ctx context.Context) ([]*ports.Port, error) {
+	got, err := n.ListPorts(ctx,
+		ports.ListOpts{DeviceOwner: SnatPortDeviceOwner},
+		config.Global.Default.Host,
+	)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*ports.Port, 0, len(got))
+	for i := range got {
+		p := got[i].Port
+		out = append(out, &p)
+	}
+	return out, nil
+}

--- a/internal/neutron/snat_pool_test.go
+++ b/internal/neutron/snat_pool_test.go
@@ -306,3 +306,44 @@ func TestEnsureServiceSnatPorts_SkipsRebindWhenHostMatches(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, got, 2)
 }
+
+// TestFetchSnatPorts_Flat verifies SNAT ports are returned as a flat slice
+// (the orphan signal is per-service, not per-network).
+func TestFetchSnatPorts_Flat(t *testing.T) {
+	fakeServer := th.SetupPersistentPortHTTP(t, 8931)
+	defer fakeServer.Teardown()
+	config.Global.Default.Host = "host-a"
+
+	listResponse := fmt.Sprintf(`{"ports":[
+        {"id": "p0", "name": "snat-svc-A-0", "device_owner": "network:f5snat",
+         "device_id": "svc-A", "network_id": "net-1",
+         "fixed_ips": [{"subnet_id": %q, "ip_address": "10.0.0.10"}]},
+        {"id": "p1", "name": "snat-svc-B-0", "device_owner": "network:f5snat",
+         "device_id": "svc-B", "network_id": "net-2",
+         "fixed_ips": [{"subnet_id": %q, "ip_address": "10.0.0.11"}]}
+    ]}`, SubnetIDFixture, SubnetIDFixture)
+	fixture.SetupHandler(t, fakeServer, "/v2.0/ports", "GET", "", listResponse, http.StatusOK)
+
+	n := &NeutronClient{ServiceClient: fake.ServiceClient(fakeServer)}
+	n.InitCache()
+
+	got, err := n.FetchSnatPorts(context.Background())
+	assert.NoError(t, err)
+	assert.Len(t, got, 2)
+	deviceIDs := []string{got[0].DeviceID, got[1].DeviceID}
+	assert.Contains(t, deviceIDs, "svc-A")
+	assert.Contains(t, deviceIDs, "svc-B")
+}
+
+func TestFetchSnatPorts_Empty(t *testing.T) {
+	fakeServer := th.SetupPersistentPortHTTP(t, 8931)
+	defer fakeServer.Teardown()
+	fixture.SetupHandler(t, fakeServer, "/v2.0/ports", "GET", "", `{"ports":[]}`, http.StatusOK)
+
+	n := &NeutronClient{ServiceClient: fake.ServiceClient(fakeServer)}
+	n.InitCache()
+
+	got, err := n.FetchSnatPorts(context.Background())
+	assert.NoError(t, err)
+	assert.Len(t, got, 0)
+}

--- a/models/service.go
+++ b/models/service.go
@@ -123,7 +123,7 @@ type Service struct {
 	// Require explicit project approval for the service owner.
 	RequireApproval *bool `json:"require_approval,omitempty"`
 
-	// Number of SNAT IP addresses allocated for this service. Increase to scale outbound port capacity. When unset, the agent uses its default behavior. Provider support varies; the cp provider does not support custom values.
+	// Number of SNAT IP addresses allocated for this service. Increase to scale outbound port capacity. Defaults to 1 when omitted on create. The cp provider does not support custom values.
 	//
 	// Maximum: 8
 	// Minimum: 1

--- a/models/service_updatable.go
+++ b/models/service_updatable.go
@@ -77,7 +77,7 @@ type ServiceUpdatable struct {
 	// Require explicit project approval for the service owner.
 	RequireApproval *bool `json:"require_approval,omitempty"`
 
-	// Number of SNAT IP addresses allocated for this service. Increase to scale outbound port capacity. Set to null to reset to default behavior. Provider support varies; the cp provider does not support custom values.
+	// Number of SNAT IP addresses allocated for this service. Increase to scale outbound port capacity. Omit to leave the current value unchanged. The cp provider does not support custom values.
 	//
 	// Maximum: 8
 	// Minimum: 1

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -2048,7 +2048,7 @@ func init() {
           "default": false
         },
         "snat_pool_size": {
-          "description": "Number of SNAT IP addresses allocated for this service. Increase to scale outbound port capacity. When unset, the agent uses its default behavior. Provider support varies; the cp provider does not support custom values.\n",
+          "description": "Number of SNAT IP addresses allocated for this service. Increase to scale outbound port capacity. Defaults to 1 when omitted on create. The cp provider does not support custom values.\n",
           "type": "integer",
           "format": "int32",
           "maximum": 8,
@@ -2162,7 +2162,7 @@ func init() {
           "x-nullable": true
         },
         "snat_pool_size": {
-          "description": "Number of SNAT IP addresses allocated for this service. Increase to scale outbound port capacity. Set to null to reset to default behavior. Provider support varies; the cp provider does not support custom values.\n",
+          "description": "Number of SNAT IP addresses allocated for this service. Increase to scale outbound port capacity. Omit to leave the current value unchanged. The cp provider does not support custom values.\n",
           "type": "integer",
           "format": "int32",
           "maximum": 8,
@@ -4578,7 +4578,7 @@ func init() {
           "default": false
         },
         "snat_pool_size": {
-          "description": "Number of SNAT IP addresses allocated for this service. Increase to scale outbound port capacity. When unset, the agent uses its default behavior. Provider support varies; the cp provider does not support custom values.\n",
+          "description": "Number of SNAT IP addresses allocated for this service. Increase to scale outbound port capacity. Defaults to 1 when omitted on create. The cp provider does not support custom values.\n",
           "type": "integer",
           "format": "int32",
           "maximum": 8,
@@ -4693,7 +4693,7 @@ func init() {
           "x-nullable": true
         },
         "snat_pool_size": {
-          "description": "Number of SNAT IP addresses allocated for this service. Increase to scale outbound port capacity. Set to null to reset to default behavior. Provider support varies; the cp provider does not support custom values.\n",
+          "description": "Number of SNAT IP addresses allocated for this service. Increase to scale outbound port capacity. Omit to leave the current value unchanged. The cp provider does not support custom values.\n",
           "type": "integer",
           "format": "int32",
           "maximum": 8,

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1429,9 +1429,8 @@ definitions:
         x-omitempty: true
         description: >
           Number of SNAT IP addresses allocated for this service. Increase to
-          scale outbound port capacity. When unset, the agent uses its default
-          behavior. Provider support varies; the cp provider does not support
-          custom values.
+          scale outbound port capacity. Defaults to 1 when omitted on create.
+          The cp provider does not support custom values.
   ServiceStatus:
     type: string
     description: |
@@ -1538,9 +1537,8 @@ definitions:
         x-omitempty: true
         description: >
           Number of SNAT IP addresses allocated for this service. Increase to
-          scale outbound port capacity. Set to null to reset to default
-          behavior. Provider support varies; the cp provider does not support
-          custom values.
+          scale outbound port capacity. Omit to leave the current value
+          unchanged. The cp provider does not support custom values.
   EndpointConsumer:
     type: object
     properties:


### PR DESCRIPTION
Drops the legacy SelfIP-as-SNAT branch in the F5 agent. Every tenant service now allocates a dedicated Neutron SNAT port pool (`network:f5snat` ports), sized by `snat_pool_size` which defaults to 1 and is no longer optional in storage.

The new migration backfills `NULL → 1` (preserving any existing non-NULL value an operator already set), `SET NOT NULL DEFAULT 1`, and tightens the CHECK to `BETWEEN 1 AND 8`.

`Service.snat_pool_size` stays nullable on the wire (`*int32`): nil from the client means *use the DB default*. The POST INSERT binds the literal SQL `DEFAULT` keyword in that case, so the column DEFAULT (1) fires server-side rather than the controller inventing a value. Non-tenant providers still reject any client-supplied `snat_pool_size`.

Adds an orphan-cleanup pass for SNAT pool ports (`cleanOrphanedSnatPorts`): walks every `network:f5snat` port bound to this host and deletes those whose `device_id` no longer maps to a live service in the DB. Catches ports stranded by deletions that bypassed PENDING_DELETE or by failed cleanup runs that left the row already gone. Distinct from the SelfIP orphan path because the signal is per-service, not per-segment.

**Upgrade impact:** services that previously used per-device SelfIP IPs as their SNAT addresses will be reallocated dedicated SNAT ports on the next agent sync. In-flight connections through the old SNAT addresses will be reset.