### PR TITLE
f5: fix ProcessServices panic on missing SelfIP port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- F5 agent: `ProcessServices` no longer panics with a nil-pointer dereference in `EnsureSelfIPs` when a subnet has no matching Neutron SelfIP ports yet. Services don't need per-device SelfIPs (only endpoints do, and `ProcessEndpoint` already ensures them), so the redundant call has been removed. `EnsureSelfIPs` now also skips (rather than dereferences) devices with no port when invoked in dry-run.
+
 ## [2.5.0] - 2026-06-22
 
 ### Changed

--- a/internal/agent/f5/l2.go
+++ b/internal/agent/f5/l2.go
@@ -126,15 +126,27 @@ func (a *Agent) EnsureSelfIPs(ctx context.Context, subnetID string, dryRun bool)
 		return err
 	}
 
+	mask, err := a.neutron.GetMask(ctx, subnetID)
+	if err != nil {
+		return err
+	}
+
 	for _, big := range a.devices {
-		// Fetch netmask
-		mask, err := a.neutron.GetMask(ctx, subnetID)
-		if err != nil {
-			return err
+		port, ok := neutronPorts[big.GetHostname()]
+		if !ok || port == nil {
+			// In dryRun mode EnsureNeutronSelfIPs does not create missing ports, so a device
+			// may legitimately be absent from the map on the first pass. Skip it — the next
+			// non-dryRun invocation (from the endpoint path) will materialize the port.
+			log.WithFields(log.Fields{"device": big.GetHostname(), "subnetID": subnetID, "dryRun": dryRun}).
+				Debug("EnsureSelfIPs: no neutron port for device, skipping")
+			continue
+		}
+		if len(port.FixedIPs) == 0 {
+			return fmt.Errorf("EnsureSelfIPs: no fixedIPs on neutron port %s for device %s", port.ID, big.GetHostname())
 		}
 
-		name := fmt.Sprint("selfip-", neutronPorts[big.GetHostname()].ID)
-		ip := neutronPorts[big.GetHostname()].FixedIPs[0].IPAddress
+		name := fmt.Sprint("selfip-", port.ID)
+		ip := port.FixedIPs[0].IPAddress
 		address := fmt.Sprint(ip, "%", segmentID, "/", mask)
 		if err := big.EnsureBigIPSelfIP(name, address, segmentID); err != nil {
 			return err

--- a/internal/agent/f5/services.go
+++ b/internal/agent/f5/services.go
@@ -170,9 +170,6 @@ func (a *Agent) ProcessServices(ctx context.Context) error {
 			if err := a.EnsureL2(ctx, service.SegmentId, nil, service.MTU); err != nil {
 				return err
 			}
-			if err := a.EnsureSelfIPs(ctx, service.SubnetID, true); err != nil {
-				return err
-			}
 		}
 	}
 


### PR DESCRIPTION
ProcessServices called `EnsureSelfIPs` with `dryRun=true`, so `EnsureNeutronSelfIPs` returned only pre-existing ports and any device without a matching SelfIP port was absent from the result map. The loop then dereferenced a nil `*ports.Port` at `l2.go:136` and crashed the scheduled sync goroutine.

Services don't actually need per-device SelfIPs — SelfIPs are BIG-IP's addresses on the tenant VLAN and only matter for reaching endpoint traffic. `ProcessEndpoint` already ensures them. Service SNAT is handled by dedicated per-service SNAT ports (allocated in `getExtendedService` via `EnsureServiceSnatPorts`) and provisioned on BIG-IP declaratively through the AS3 `SnatPool` object in `GetServiceTenants` — no separate ensure step exists or is needed. The call at `services.go:173` was a leftover from the pre-2.5.0 model where services and endpoints shared SelfIPs for SNAT.

Changes:
- Drop the redundant `EnsureSelfIPs` call from `ProcessServices`.
- Harden `EnsureSelfIPs`: skip devices with no port (defensive against dryRun callers), reject ports with no fixed IPs, and hoist the device-independent `GetMask` call out of the loop.