### PR TITLE
f5: restore EnsureSelfIPs on service subnet in ProcessServices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- F5 agent: `ProcessServices` now provisions a SelfIP on the service subnet again. The 2.5.1 fix removed the call under the assumption that only endpoints need SelfIPs, but the AS3 SnatPool addresses and pool members are pinned to the service's route domain and require the BIG-IP to have L3 presence on the service VLAN — otherwise ARP for SNAT IPs and health monitors against pool members fail. The nil-pointer hardening in `EnsureSelfIPs` from 2.5.1 is retained; the new call runs with `dryRun=false` so the Neutron port is materialized and the SelfIP is created on the device.
+
 ## [2.5.1] - 2026-07-01
 
 ### Fixed

--- a/internal/agent/f5/services.go
+++ b/internal/agent/f5/services.go
@@ -170,6 +170,10 @@ func (a *Agent) ProcessServices(ctx context.Context) error {
 			if err := a.EnsureL2(ctx, service.SegmentId, nil, service.MTU); err != nil {
 				return err
 			}
+			// SelfIP on service subnet: BIG-IP L3 presence for SNAT pool and pool members in the service route domain.
+			if err := a.EnsureSelfIPs(ctx, service.SubnetID, false); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
The 2.5.1 fix removed the `EnsureSelfIPs` call from `ProcessServices` on the assumption that services don't need per-device SelfIPs. That's wrong: the AS3 SnatPool addresses and pool members are both pinned to the service's route domain (`service.SegmentId`), so the BIG-IP needs a SelfIP on the service VLAN — otherwise ARP for the SNAT IPs has no responder, the device can't source SNAT traffic from that RD, and health monitors against pool members fail.

Endpoints ensure SelfIPs on the *endpoint* subnet, not the service subnet, so the endpoint path is not a substitute in the usual private-connectivity topology where services and endpoints live on different networks.

Restores the call with `dryRun=false` — the pre-2.5.1 code passed `true`, which is what caused the original nil-deref panic (`EnsureNeutronSelfIPs` returned only pre-existing ports). The defensive hardening from 2.5.1 (`EnsureSelfIPs` skips devices with no port and rejects ports with no FixedIPs) is kept as a belt-and-suspenders guard.