### PR TITLE
Add release-prepare target to sync swagger.yaml version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ swagger:
 	swagger generate client --copyright-file COPYRIGHT.txt
 markdown:
 	swagger generate markdown --copyright-file COPYRIGHT.txt --output=docs/api.md
+# Invoked by the release-pr GitHub workflow with VERSION set to the bumped
+# version. Keeps swagger.yaml's version in sync with the release tag.
+release-prepare:
+	$(SED) -i 's/^  version: .*/  version: "$(VERSION)"/' swagger.yaml
 
 install-goimports: FORCE
 	@if ! hash goimports 2>/dev/null; then printf "\e[1;36m>> Installing goimports (this may take a while)...\e[0m\n"; go install golang.org/x/tools/cmd/goimports@latest; fi

--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -85,6 +85,10 @@ verbatim: |
       swagger generate client --copyright-file COPYRIGHT.txt
   markdown:
       swagger generate markdown --copyright-file COPYRIGHT.txt --output=docs/api.md
+  # Invoked by the release-pr GitHub workflow with VERSION set to the bumped
+  # version. Keeps swagger.yaml's version in sync with the release tag.
+  release-prepare:
+      $(SED) -i 's/^  version: .*/  version: "$(VERSION)"/' swagger.yaml
 
 coverageTest:
   only: '/internal'


### PR DESCRIPTION
go-makefile-maker [PR #531](https://github.com/sapcc/go-makefile-maker/pull/531) replaced the standalone `draft-release.yml` workflow with the generated `release-pr.yaml`. That generated workflow invokes `make release-prepare` (with `VERSION` set to the bumped version) *if the target exists* — which is where the release pipeline used to rewrite `swagger.yaml`'s version. Without the target defined, the step logged "No release-prepare target defined; skipping" and the swagger version bump was silently lost.

This adds the `release-prepare` target (via the `verbatim` block in `Makefile.maker.yaml`, then regenerated into the Makefile) to rewrite the `swagger.yaml` version line. It uses the Makefile's `$(SED)` variable, which resolves to GNU sed on both Linux/CI (`sed`) and macOS (`gsed`), so the `-i` invocation stays portable and avoids BSD sed's incompatible `-i` semantics.