### PR TITLE
Bound FOR UPDATE lock waits, and quiet context-cancel noise (499 + Sentry filter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Requests whose context is cancelled or times out (e.g. the client disconnects or the request deadline is hit while waiting on a `FOR UPDATE` row lock) no longer surface as HTTP 500 with an error-level stack trace. The recovery middleware now detects context-cancellation panics and returns HTTP 499 (Client Closed Request), logged at info level.
+
 ## [2.5.3] - 2026-07-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - API handlers that lock a service row with `FOR UPDATE` (service delete, service migrate, endpoint create) now bound the lock wait with a 5s `lock_timeout` instead of blocking until the 30s request deadline. When the lock is held by another operation (e.g. an agent mid-reconcile), the handler now returns HTTP 503 with a `Retry-After` header, and logs the blocking session — its PID, `application_name`, state, how long it has held the lock, and its running query — so the actual lock holder can be identified from the logs.
-- Requests whose context is cancelled or times out (e.g. the client disconnects or the request deadline is hit while waiting on a `FOR UPDATE` row lock) no longer surface as HTTP 500 with an error-level stack trace. The recovery middleware now detects context-cancellation panics and returns HTTP 499 (Client Closed Request), logged at info level.
+- Requests whose context is cancelled or times out (e.g. the client disconnects or the request deadline is hit while waiting on a `FOR UPDATE` row lock) no longer surface as HTTP 500 with an error-level stack trace. The recovery middleware now detects context-cancellation panics and returns HTTP 499 (Client Closed Request), logged at info level. Such panics are also filtered out in Sentry via `BeforeSend`, so client disconnects no longer create Sentry issues.
 
 ## [2.5.3] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- API handlers that lock a service row with `FOR UPDATE` (service delete, service migrate, endpoint create) now bound the lock wait with a 5s `lock_timeout` instead of blocking until the 30s request deadline. When the lock is held by another operation (e.g. an agent mid-reconcile), the handler now returns HTTP 503 with a `Retry-After` header, and logs the blocking session — its PID, `application_name`, state, how long it has held the lock, and its running query — so the actual lock holder can be identified from the logs.
 - Requests whose context is cancelled or times out (e.g. the client disconnects or the request deadline is hit while waiting on a `FOR UPDATE` row lock) no longer surface as HTTP 500 with an error-level stack trace. The recovery middleware now detects context-cancellation panics and returns HTTP 499 (Client Closed Request), logged at info level.
 
 ## [2.5.3] - 2026-07-10

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,8 @@
 package config
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -188,6 +190,17 @@ func InitSentry() {
 			AttachStacktrace: true,
 			Release:          Version,
 			ServerName:       Global.Default.Host,
+			BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+				// A canceled or timed-out request context is a client-side
+				// condition (disconnect or request deadline), not a server
+				// fault. The recovery middleware already maps these to HTTP 499;
+				// don't also report them to Sentry.
+				if hint != nil && (errors.Is(hint.OriginalException, context.Canceled) ||
+					errors.Is(hint.OriginalException, context.DeadlineExceeded)) {
+					return nil
+				}
+				return event
+			},
 		}); err != nil {
 			log.Fatalf("Sentry initialization failed: %v", err)
 		}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -5,6 +5,8 @@
 package controller
 
 import (
+	"time"
+
 	"github.com/go-openapi/loads"
 
 	"github.com/sapcc/archer/v2/internal/db"
@@ -12,13 +14,22 @@ import (
 	"github.com/sapcc/archer/v2/internal/notifier"
 )
 
+// defaultLockTimeout bounds how long a FOR UPDATE handler transaction waits for
+// a row lock before failing with a lock_not_available error. It must stay well
+// below the HTTP request deadline so a contended lock surfaces as a clean,
+// retryable 503 instead of hanging until the request is cancelled.
+const defaultLockTimeout = 5 * time.Second
+
 type Controller struct {
 	spec     *loads.Document
 	pool     db.PgxIface
 	neutron  *neutron.NeutronClient
 	notifier *notifier.Notifier
+	// lockTimeout is applied to FOR UPDATE handler transactions. Overridable in
+	// tests; defaults to defaultLockTimeout.
+	lockTimeout time.Duration
 }
 
 func NewController(pool db.PgxIface, spec *loads.Document, client *neutron.NeutronClient, n *notifier.Notifier) *Controller {
-	return &Controller{pool: pool, spec: spec, neutron: client, notifier: n}
+	return &Controller{pool: pool, spec: spec, neutron: client, notifier: n, lockTimeout: defaultLockTimeout}
 }

--- a/internal/controller/endpoint.go
+++ b/internal/controller/endpoint.go
@@ -95,7 +95,7 @@ func (c *Controller) PostEndpointHandler(params endpoint.PostEndpointParams, tok
 		})
 	}
 
-	tx, err := c.pool.Begin(ctx)
+	tx, err := db.BeginWithLockTimeout(ctx, c.pool, c.lockTimeout)
 	if err != nil {
 		panic(err)
 	}
@@ -127,6 +127,9 @@ func (c *Controller) PostEndpointHandler(params endpoint.PostEndpointParams, tok
 				Message: fmt.Sprintf("Service '%s' is not accessible.",
 					params.Body.ServiceID),
 			})
+		}
+		if db.IsLockTimeout(err) {
+			db.LogLockBlockers(ctx, c.pool, "service")
 		}
 		panic(err)
 	}

--- a/internal/controller/service.go
+++ b/internal/controller/service.go
@@ -445,7 +445,7 @@ func (c *Controller) DeleteServiceServiceIDHandler(params service.DeleteServiceS
 		q = q.Where("project_id = ?", projectId)
 	}
 
-	tx, err := c.pool.Begin(params.HTTPRequest.Context())
+	tx, err := db.BeginWithLockTimeout(params.HTTPRequest.Context(), c.pool, c.lockTimeout)
 	if err != nil {
 		panic(err)
 	}
@@ -456,6 +456,9 @@ func (c *Controller) DeleteServiceServiceIDHandler(params service.DeleteServiceS
 	if err := tx.QueryRow(params.HTTPRequest.Context(), sql, args...).Scan(&host); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return service.NewDeleteServiceServiceIDNotFound()
+		}
+		if db.IsLockTimeout(err) {
+			db.LogLockBlockers(params.HTTPRequest.Context(), c.pool, "service")
 		}
 		panic(err)
 	}
@@ -763,6 +766,10 @@ func (c *Controller) PostServiceServiceIDMigrateHandler(params service.PostServi
 	var az *string
 
 	if err := pgx.BeginFunc(ctx, c.pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL lock_timeout = %d", c.lockTimeout.Milliseconds())); err != nil {
+			return err
+		}
+
 		// Get current service details
 		sql, args := db.Select("host", "provider", "availability_zone").
 			From("service").
@@ -878,6 +885,9 @@ func (c *Controller) PostServiceServiceIDMigrateHandler(params service.PostServi
 				Code:    400,
 				Message: "Service is already on the target host",
 			})
+		}
+		if db.IsLockTimeout(err) {
+			db.LogLockBlockers(ctx, c.pool, "service")
 		}
 		panic(err)
 	}

--- a/internal/controller/service_test.go
+++ b/internal/controller/service_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
 
 	sq "github.com/Masterminds/squirrel"
 	policy "github.com/databus23/goslo.policy"
@@ -17,6 +18,8 @@ import (
 	"github.com/go-openapi/swag/conv"
 	"github.com/gophercloud/gophercloud/v2/testhelper/fixture"
 	"github.com/sapcc/go-bits/gopherpolicy"
+	"github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sapcc/archer/v2/internal/config"
@@ -340,6 +343,95 @@ func (t *SuiteTest) TestServiceDelete() {
 			ServiceID: "11fb8be3-6154-4244-80f1-6b0bef94aa1e"},
 		nil)
 	assert.IsType(t.T(), &service.DeleteServiceServiceIDNotFound{}, res)
+}
+
+// TestServiceDeleteLockContention reproduces the incident: a concurrent holder
+// keeps a FOR UPDATE lock on the service row while the DELETE handler tries to
+// acquire it. With the bounded lock_timeout the handler must fail fast with a
+// lock-timeout panic well before the (30s) request deadline, rather than
+// blocking and panicking on a cancelled context. The recovery middleware maps
+// that panic to a retryable 503 (see the middlewares package tests).
+func (t *SuiteTest) TestServiceDeleteLockContention() {
+	serviceId := t.createService(testService)
+
+	// Shorten the lock timeout for the test and restore it afterwards.
+	orig := t.c.lockTimeout
+	t.c.lockTimeout = 500 * time.Millisecond
+	defer func() { t.c.lockTimeout = orig }()
+
+	// Hold a FOR UPDATE lock on the service row in a separate transaction,
+	// simulating an agent mid-reconcile.
+	holderTx, err := t.c.pool.Begin(context.Background())
+	assert.NoError(t.T(), err)
+	defer func() { _ = holderTx.Rollback(context.Background()) }()
+
+	sql, args := db.Select("id").From("service").
+		Where("id = ?", serviceId).Suffix("FOR UPDATE").MustSql()
+	var lockedID strfmt.UUID
+	assert.NoError(t.T(), holderTx.QueryRow(context.Background(), sql, args...).Scan(&lockedID))
+
+	// The DELETE handler should panic with a lock-timeout error promptly
+	// (bounded by lock_timeout), not hang until the request deadline.
+	start := time.Now()
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		t.c.DeleteServiceServiceIDHandler(
+			service.DeleteServiceServiceIDParams{HTTPRequest: &headerProject1, ServiceID: serviceId},
+			nil)
+	}()
+	elapsed := time.Since(start)
+
+	assert.Less(t.T(), elapsed, 5*time.Second, "handler should fail fast on lock timeout")
+	err, ok := recovered.(error)
+	assert.True(t.T(), ok, "handler should panic with an error")
+	assert.True(t.T(), db.IsLockTimeout(err), "panic should be a lock_timeout error, got: %v", recovered)
+}
+
+// TestLogLockBlockersIntegration verifies against a real Postgres that
+// LogLockBlockers finds the session actually holding a lock on the service row
+// and reports it. A dedicated connection with a recognizable application_name
+// holds a FOR UPDATE lock inside an open transaction (mirroring an agent
+// mid-reconcile); LogLockBlockers must surface that connection.
+func (t *SuiteTest) TestLogLockBlockersIntegration() {
+	serviceId := t.createService(testService)
+
+	// Acquire a separate connection whose application_name we control, so we can
+	// unambiguously recognize it in the diagnostic output.
+	holder, err := t.c.pool.Acquire(context.Background())
+	assert.NoError(t.T(), err)
+	defer holder.Release()
+
+	_, err = holder.Exec(context.Background(), "SET application_name = 'archer-test-holder'")
+	assert.NoError(t.T(), err)
+
+	holderTx, err := holder.Begin(context.Background())
+	assert.NoError(t.T(), err)
+	defer func() { _ = holderTx.Rollback(context.Background()) }()
+
+	sql, args := db.Select("id").From("service").
+		Where("id = ?", serviceId).Suffix("FOR UPDATE").MustSql()
+	var lockedID strfmt.UUID
+	assert.NoError(t.T(), holderTx.QueryRow(context.Background(), sql, args...).Scan(&lockedID))
+
+	hook := logtest.NewGlobal()
+	defer hook.Reset()
+
+	db.LogLockBlockers(context.Background(), t.c.pool, "service")
+
+	// Find the error-level entry naming our holder connection.
+	var found *logrus.Entry
+	for _, e := range hook.AllEntries() {
+		if e.Level == logrus.ErrorLevel && e.Data["application_name"] == "archer-test-holder" {
+			found = e
+			break
+		}
+	}
+	if assert.NotNil(t.T(), found, "LogLockBlockers should report the holding session") {
+		assert.Equal(t.T(), "service", found.Data["relation"])
+		assert.Contains(t.T(), found.Data["blocker_query"], "FOR UPDATE")
+		assert.NotEmpty(t.T(), found.Data["blocker_pid"])
+	}
 }
 
 func (t *SuiteTest) TestServiceDuplicatePayload() {

--- a/internal/db/locks.go
+++ b/internal/db/locks.go
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/georgysavva/scany/v2/pgxscan"
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+	log "github.com/sirupsen/logrus"
+)
+
+// BeginWithLockTimeout starts a transaction and bounds how long any statement in
+// it will wait for a row/table lock via `SET LOCAL lock_timeout`. Once the
+// timeout elapses the blocked statement fails immediately with SQLSTATE 55P03
+// (lock_not_available) instead of hanging until the request context deadline.
+//
+// lock_timeout should be chosen well below the HTTP request deadline so a
+// contended FOR UPDATE surfaces as a clean, retryable error rather than an
+// opaque context cancellation. SET LOCAL is scoped to the transaction and is
+// reset automatically on commit or rollback.
+func BeginWithLockTimeout(ctx context.Context, pool PgxIface, timeout time.Duration) (pgx.Tx, error) {
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Milliseconds keeps the value integral for any sub-second timeout.
+	ms := timeout.Milliseconds()
+	if _, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL lock_timeout = %d", ms)); err != nil {
+		_ = tx.Rollback(ctx)
+		return nil, fmt.Errorf("failed to set lock_timeout: %w", err)
+	}
+	return tx, nil
+}
+
+// IsLockTimeout reports whether err is a Postgres lock_not_available (55P03)
+// error, i.e. a lock wait that exceeded lock_timeout.
+func IsLockTimeout(err error) bool {
+	pe, ok := errors.AsType[*pgconn.PgError](err)
+	return ok && pe.Code == pgerrcode.LockNotAvailable
+}
+
+// lockBlocker is one session holding a lock on the queried relation.
+type lockBlocker struct {
+	PID         int32       `db:"pid"`
+	Application string      `db:"application_name"`
+	State       string      `db:"state"`
+	RunningForS float64     `db:"running_for_s"`
+	WaitType    pgtype.Text `db:"wait_event_type"`
+	Query       string      `db:"query"`
+}
+
+// LogLockBlockers dumps the sessions currently holding locks on the given
+// relation to the log at error level. It is meant to be called from a handler's
+// lock-timeout branch to capture *who* was blocking — the tuple/relation in the
+// Postgres server log only identifies the blocked row, never the holder.
+//
+// It runs on a fresh pool connection (the transaction that hit the lock timeout
+// is left in an aborted state and cannot be reused). Because every archer
+// process sets a distinct application_name (archer-api, archer-f5-agent,
+// archer-ni-agent), the dump names the culprit process and its running query
+// directly. This is best-effort diagnostics: any failure is logged and swallowed
+// so it never masks the original lock error.
+func LogLockBlockers(ctx context.Context, pool PgxIface, relation string) {
+	q, args := Select(
+		"a.pid",
+		"a.application_name",
+		"a.state",
+		"COALESCE(EXTRACT(EPOCH FROM (now() - a.query_start)), 0) AS running_for_s",
+		"a.wait_event_type",
+		"left(a.query, 500) AS query",
+	).
+		From("pg_stat_activity a").
+		Join("pg_locks l ON l.pid = a.pid").
+		Join("pg_class c ON c.oid = l.relation").
+		Where("c.relname = ?", relation).
+		Where("a.pid <> pg_backend_pid()").
+		Where("a.state <> 'idle'").
+		OrderBy("a.query_start").
+		MustSql()
+
+	var blockers []lockBlocker
+	if err := pgxscan.Select(ctx, pool, &blockers, q, args...); err != nil {
+		log.WithError(err).Warnf("LogLockBlockers: failed to query lock holders for %q", relation)
+		return
+	}
+
+	if len(blockers) == 0 {
+		log.WithField("relation", relation).
+			Warn("lock timeout: no active lock holder found (holder may have already released or is idle-in-transaction)")
+		return
+	}
+
+	for _, b := range blockers {
+		log.WithFields(log.Fields{
+			"relation":         relation,
+			"blocker_pid":      b.PID,
+			"application_name": b.Application,
+			"state":            b.State,
+			"running_for":      time.Duration(b.RunningForS * float64(time.Second)).Round(time.Millisecond).String(),
+			"wait_event_type":  b.WaitType.String, // empty when NULL
+			"blocker_query":    b.Query,
+		}).Error("lock timeout: blocking session holding a lock on the relation")
+	}
+}

--- a/internal/db/locks_test.go
+++ b/internal/db/locks_test.go
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/pashagolub/pgxmock/v5"
+	"github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsLockTimeout(t *testing.T) {
+	assert.True(t, IsLockTimeout(&pgconn.PgError{Code: pgerrcode.LockNotAvailable}))
+	assert.False(t, IsLockTimeout(&pgconn.PgError{Code: pgerrcode.UndefinedColumn}))
+	assert.False(t, IsLockTimeout(assert.AnError))
+	assert.False(t, IsLockTimeout(nil))
+}
+
+// logLockBlockersSQL is the exact statement LogLockBlockers emits. Kept as a
+// constant so the test fails loudly if the query builder output changes.
+const logLockBlockersSQL = "SELECT a.pid, a.application_name, a.state, " +
+	"COALESCE(EXTRACT(EPOCH FROM (now() - a.query_start)), 0) AS running_for_s, " +
+	"a.wait_event_type, left(a.query, 500) AS query " +
+	"FROM pg_stat_activity a " +
+	"JOIN pg_locks l ON l.pid = a.pid " +
+	"JOIN pg_class c ON c.oid = l.relation " +
+	"WHERE c.relname = $1 AND a.pid <> pg_backend_pid() AND a.state <> 'idle' " +
+	"ORDER BY a.query_start"
+
+func TestLogLockBlockersQuery(t *testing.T) {
+	dbMock, err := pgxmock.NewPool(pgxmock.QueryMatcherOption(pgxmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbMock.Close()
+
+	// One blocking session found: exercise the scan + log path.
+	rows := pgxmock.NewRows([]string{
+		"pid", "application_name", "state", "running_for_s", "wait_event_type", "query",
+	}).AddRow(
+		int32(611643), "archer-f5-agent", "idle in transaction",
+		float64(12.5), "Client", "SELECT ... FOR UPDATE OF service",
+	)
+
+	dbMock.ExpectQuery(logLockBlockersSQL).
+		WithArgs("service").
+		WillReturnRows(rows)
+
+	hook := logtest.NewGlobal()
+	defer hook.Reset()
+
+	LogLockBlockers(context.Background(), dbMock, "service")
+
+	assert.NoError(t, dbMock.ExpectationsWereMet())
+
+	// The blocker row must be logged at error level with the holder details —
+	// asserting this (not just "did not panic") is what catches a scan failure.
+	entry := hook.LastEntry()
+	if assert.NotNil(t, entry, "expected a log entry for the blocking session") {
+		assert.Equal(t, logrus.ErrorLevel, entry.Level)
+		assert.Equal(t, "lock timeout: blocking session holding a lock on the relation", entry.Message)
+		assert.Equal(t, int32(611643), entry.Data["blocker_pid"])
+		assert.Equal(t, "archer-f5-agent", entry.Data["application_name"])
+		assert.Equal(t, "idle in transaction", entry.Data["state"])
+		assert.Equal(t, "Client", entry.Data["wait_event_type"])
+		assert.Equal(t, "12.5s", entry.Data["running_for"])
+		assert.Equal(t, "SELECT ... FOR UPDATE OF service", entry.Data["blocker_query"])
+	}
+}
+
+func TestLogLockBlockersNoRows(t *testing.T) {
+	dbMock, err := pgxmock.NewPool(pgxmock.QueryMatcherOption(pgxmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbMock.Close()
+
+	empty := pgxmock.NewRows([]string{
+		"pid", "application_name", "state", "running_for_s", "wait_event_type", "query",
+	})
+	dbMock.ExpectQuery(logLockBlockersSQL).
+		WithArgs("service").
+		WillReturnRows(empty)
+
+	hook := logtest.NewGlobal()
+	defer hook.Reset()
+
+	// No holder found: must not panic, and must not log a (false) error-level
+	// "blocking session" entry.
+	LogLockBlockers(context.Background(), dbMock, "service")
+
+	assert.NoError(t, dbMock.ExpectationsWereMet())
+	entry := hook.LastEntry()
+	if assert.NotNil(t, entry) {
+		assert.Equal(t, logrus.WarnLevel, entry.Level)
+	}
+}
+
+func TestLogLockBlockersQueryError(t *testing.T) {
+	dbMock, err := pgxmock.NewPool(pgxmock.QueryMatcherOption(pgxmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbMock.Close()
+
+	dbMock.ExpectQuery(logLockBlockersSQL).
+		WithArgs("service").
+		WillReturnError(assert.AnError)
+
+	// Diagnostics are best-effort: a query failure must be swallowed, not panic.
+	assert.NotPanics(t, func() {
+		LogLockBlockers(context.Background(), dbMock, "service")
+	})
+
+	assert.NoError(t, dbMock.ExpectationsWereMet())
+}

--- a/internal/middlewares/recovery.go
+++ b/internal/middlewares/recovery.go
@@ -5,12 +5,19 @@
 package middlewares
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"runtime/debug"
 
 	log "github.com/sirupsen/logrus"
 )
+
+// clientClosedRequest is the (unofficial but widely used) HTTP status code for
+// a request whose context was canceled by the client or by hitting the
+// request deadline. It signals that the failure is not a server fault.
+const clientClosedRequest = 499
 
 // RecoveryMiddleware catches panics from downstream handlers, logs them with a
 // stack trace, and writes a plain 500 response. It is intended to wrap the
@@ -19,6 +26,11 @@ import (
 //
 // The 500 is written via WriteHeader so that any outer Prometheus
 // instrumentation observes the correct status code.
+//
+// Panics caused solely by a canceled or timed-out request context (e.g. a
+// handler panicking on the error returned when a FOR UPDATE lock wait exceeds
+// the request deadline) are a client-side condition, not a server fault. Those
+// are converted to HTTP 499 and logged at info level without a stack trace.
 func RecoveryMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
@@ -30,6 +42,18 @@ func RecoveryMiddleware(next http.Handler) http.Handler {
 			err, ok := rec.(error)
 			if !ok {
 				err = fmt.Errorf("%v", rec)
+			}
+
+			// A canceled/timed-out request context is not a server bug.
+			// Avoid the error-level log + stack trace and report 499.
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				log.WithFields(log.Fields{
+					"method": r.Method,
+					"path":   r.URL.Path,
+				}).Infof("request context cancelled: %v", err)
+
+				w.WriteHeader(clientClosedRequest)
+				return
 			}
 
 			log.WithFields(log.Fields{

--- a/internal/middlewares/recovery.go
+++ b/internal/middlewares/recovery.go
@@ -12,6 +12,8 @@ import (
 	"runtime/debug"
 
 	log "github.com/sirupsen/logrus"
+
+	"github.com/sapcc/archer/v2/internal/db"
 )
 
 // clientClosedRequest is the (unofficial but widely used) HTTP status code for
@@ -31,6 +33,11 @@ const clientClosedRequest = 499
 // handler panicking on the error returned when a FOR UPDATE lock wait exceeds
 // the request deadline) are a client-side condition, not a server fault. Those
 // are converted to HTTP 499 and logged at info level without a stack trace.
+//
+// Panics caused by a bounded FOR UPDATE lock wait timing out (the row is busy,
+// typically an agent mid-reconcile) are converted to HTTP 503 with a
+// Retry-After header — retryable, and not a server bug. The handler is expected
+// to have already logged the blocking session before re-panicking.
 func RecoveryMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
@@ -53,6 +60,19 @@ func RecoveryMiddleware(next http.Handler) http.Handler {
 				}).Infof("request context cancelled: %v", err)
 
 				w.WriteHeader(clientClosedRequest)
+				return
+			}
+
+			// A bounded FOR UPDATE lock wait timed out: the row is busy, not a
+			// server fault. Report a retryable 503.
+			if db.IsLockTimeout(err) {
+				log.WithFields(log.Fields{
+					"method": r.Method,
+					"path":   r.URL.Path,
+				}).Infof("lock timeout, responding 503: %v", err)
+
+				w.Header().Set("Retry-After", "5")
+				w.WriteHeader(http.StatusServiceUnavailable)
 				return
 			}
 

--- a/internal/middlewares/recovery_test.go
+++ b/internal/middlewares/recovery_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -44,6 +45,16 @@ func TestRecoveryMiddleware(t *testing.T) {
 			name:       "wrapped context canceled becomes 499",
 			panicValue: fmt.Errorf("failed to send query: %w", context.Canceled),
 			wantStatus: clientClosedRequest,
+		},
+		{
+			name:       "lock timeout becomes 503",
+			panicValue: &pgconn.PgError{Code: "55P03"},
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name:       "wrapped lock timeout becomes 503",
+			panicValue: fmt.Errorf("query failed: %w", &pgconn.PgError{Code: "55P03"}),
+			wantStatus: http.StatusServiceUnavailable,
 		},
 	}
 

--- a/internal/middlewares/recovery_test.go
+++ b/internal/middlewares/recovery_test.go
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Copyright 2026 SAP SE or an SAP affiliate company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package middlewares
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRecoveryMiddleware(t *testing.T) {
+	tests := []struct {
+		name       string
+		panicValue any
+		wantStatus int
+	}{
+		{
+			name:       "no panic passes through",
+			panicValue: nil,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "generic panic becomes 500",
+			panicValue: fmt.Errorf("boom"),
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:       "context canceled becomes 499",
+			panicValue: context.Canceled,
+			wantStatus: clientClosedRequest,
+		},
+		{
+			name:       "deadline exceeded becomes 499",
+			panicValue: context.DeadlineExceeded,
+			wantStatus: clientClosedRequest,
+		},
+		{
+			name:       "wrapped context canceled becomes 499",
+			panicValue: fmt.Errorf("failed to send query: %w", context.Canceled),
+			wantStatus: clientClosedRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := RecoveryMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if tt.panicValue != nil {
+					panic(tt.panicValue)
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodDelete, "/service/123", nil)
+
+			assert.NotPanics(t, func() {
+				handler.ServeHTTP(rec, req)
+			})
+			assert.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
+}


### PR DESCRIPTION
A `FOR UPDATE` on the `service` row could block for the full 30s request deadline when another transaction held it — e.g. an agent holding the lock across a slow BigIP/Neutron call — then panic on the cancelled context, producing a noisy 500 (and blowing up the old recovr middleware).

Three commits:

- A small in-tree panic recovery middleware (replacing `dre1080/recovr`) that maps context-cancel/deadline panics to HTTP 499 instead of an error-level 500 stack trace.
- The service delete/migrate and endpoint create handlers now set a 5s `lock_timeout`, so a contended lock fails fast with SQLSTATE 55P03 rather than hanging. On timeout the handler dumps the blocking session (PID, `application_name`, state, hold duration, running query) from `pg_stat_activity`/`pg_locks`, then re-panics; the recovery middleware maps that to a retryable 503 with `Retry-After`.
- A Sentry `BeforeSend` filter that drops events whose `OriginalException` is `context.Canceled`/`context.DeadlineExceeded`. Sentry runs inside the recovery middleware with `Repanic:true`, so it captured these client-side conditions before recovery could downgrade them — meaning client disconnects were still creating Sentry issues. This stops that noise at the source.

The server log only ever named the *blocked* tuple, never the holder. Since each archer process sets a distinct `application_name`, the new blocker dump names the culprit directly — turning a recurrence from inference into evidence. The underlying agent refactor (not holding row locks across BigIP I/O) remains a follow-up.